### PR TITLE
keep curl when removing unused APT resources

### DIFF
--- a/debian8/Dockerfile
+++ b/debian8/Dockerfile
@@ -25,7 +25,7 @@ RUN echo "===> Installing python, sudo, and supporting tools..."  && \
     \
     \
     echo "===> Removing unused APT resources..."                       && \
-    apt-get -f -y --auto-remove remove curl gcc python-pip python-dev  && \
+    apt-get -f -y --auto-remove remove gcc python-pip python-dev  && \
     apt-get clean                                                      && \
     rm -rf /var/lib/apt/lists/*  /tmp/*                                && \
     \


### PR DESCRIPTION
Hi William,
downloading roles (see http://docs.ansible.com/ansible/galaxy.html#advanced-control-over-role-requirements-files) fails if curl is not available. Here's what I want to do:

```
$ cat requirements.yml 
- src: https://github.com/hajaalin/ansible-role/archive/v0.1.1.tar.gz
  name: myrole

# in Dockerfile
COPY requirements.yml /tmp/requirements.yml
RUN ansible-galaxy install -r /tmp/requirements.yml
```

Not removing curl seems to be enough to fix it.
Best,
Harri
