### PR TITLE
Add: systemd support in CentOS 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,14 +44,14 @@ before_install:
     - docker build  -t ansible_master_precise          master-ubuntu12.04
     - docker build  -t ansible_master_jessie           master-debian8
     - docker build  -t ansible_master_wheezy           master-debian7
-    #- docker build  -t ansible_master_centos7          master-centos7
+    - docker build  -t ansible_master_centos7          master-centos7
     - docker build  -t ansible_master_centos6          master-centos6
 
     - docker build  -t ansible_master_trusty_onbuild   master-ubuntu14.04-onbuild
     - docker build  -t ansible_master_precise_onbuild  master-ubuntu12.04-onbuild
     - docker build  -t ansible_master_jessie_onbuild   master-debian8-onbuild
     - docker build  -t ansible_master_wheezy_onbuild   master-debian7-onbuild
-    #- docker build  -t ansible_master_centos7_onbuild  master-centos7-onbuild
+    - docker build  -t ansible_master_centos7_onbuild  master-centos7-onbuild
     - docker build  -t ansible_master_centos6_onbuild  master-centos6-onbuild
 
 script:
@@ -91,13 +91,13 @@ script:
     - docker run -i ansible_master_precise          > result-master-ubuntu12.04
     - docker run -i ansible_master_jessie           > result-master-debian8
     - docker run -i ansible_master_wheezy           > result-master-debian7
-    #- docker run -i ansible_master_centos7          > result-master-centos7
+    - docker run -i ansible_master_centos7          > result-master-centos7
     - docker run -i ansible_master_centos6          > result-master-centos6
     - docker run -i ansible_master_trusty_onbuild   > result-master-ubuntu14.04-onbuild
     - docker run -i ansible_master_precise_onbuild  > result-master-ubuntu12.04-onbuild
     - docker run -i ansible_master_jessie_onbuild   > result-master-debian8-onbuild
     - docker run -i ansible_master_wheezy_onbuild   > result-master-debian7-onbuild
-    #- docker run -i ansible_master_centos7_onbuild  > result-master-centos7-onbuild
+    - docker run -i ansible_master_centos7_onbuild  > result-master-centos7-onbuild
     - docker run -i ansible_master_centos6_onbuild  > result-master-centos6-onbuild
 
 
@@ -137,11 +137,11 @@ script:
     - sh -c "[ -s result-master-ubuntu12.04         ]"
     - sh -c "[ -s result-master-debian8             ]"
     - sh -c "[ -s result-master-debian7             ]"
-    #- sh -c "[ -s result-master-centos7             ]"
+    - sh -c "[ -s result-master-centos7             ]"
     - sh -c "[ -s result-master-centos6             ]"
     - sh -c "[ -s result-master-ubuntu14.04-onbuild ]"
     - sh -c "[ -s result-master-ubuntu12.04-onbuild ]"
     - sh -c "[ -s result-master-debian8-onbuild     ]"
     - sh -c "[ -s result-master-debian7-onbuild     ]"
-    #- sh -c "[ -s result-master-centos7-onbuild     ]"
+    - sh -c "[ -s result-master-centos7-onbuild     ]"
     - sh -c "[ -s result-master-centos6-onbuild     ]"

--- a/1.9-centos7-onbuild/Dockerfile
+++ b/1.9-centos7-onbuild/Dockerfile
@@ -17,7 +17,22 @@ FROM centos:centos7
 MAINTAINER William Yeh <william.pjyeh@gmail.com>
 
 
-RUN echo "===> Installing EPEL..."        && \
+# enable systemd;
+# @see https://hub.docker.com/_/centos/
+ENV container docker
+
+RUN echo "===> Enabling systemd..."  && \
+    (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;      \
+    rm -f /etc/systemd/system/*.wants/*;                      \
+    rm -f /lib/systemd/system/local-fs.target.wants/*;        \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*;    \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;           \
+    rm -f /lib/systemd/system/anaconda.target.wants/*      && \
+    \
+    \    
+    echo "===> Installing EPEL..."        && \
     yum -y install epel-release           && \
     \
     \
@@ -46,6 +61,19 @@ RUN echo "===> Installing EPEL..."        && \
     echo "===> Adding hosts for convenience..."    && \
     mkdir -p /etc/ansible                          && \
     echo 'localhost' > /etc/ansible/hosts
+
+
+#
+# [Quote] https://hub.docker.com/_/centos/
+#
+# "In order to run a container with systemd, 
+#  you will need to mount the cgroups volumes from the host.
+#  [...]
+#  There have been reports that if you're using an Ubuntu host,
+#  you will need to add -v /tmp/$(mktemp -d):/run
+#  in addition to the cgroups mount."
+#
+VOLUME [ "/sys/fs/cgroup", "/run" ]
 
 
 COPY ansible-playbook-wrapper /usr/local/bin/

--- a/1.9-centos7/Dockerfile
+++ b/1.9-centos7/Dockerfile
@@ -17,7 +17,22 @@ FROM centos:centos7
 MAINTAINER William Yeh <william.pjyeh@gmail.com>
 
 
-RUN echo "===> Installing EPEL..."        && \
+# enable systemd;
+# @see https://hub.docker.com/_/centos/
+ENV container docker
+
+RUN echo "===> Enabling systemd..."  && \
+    (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;      \
+    rm -f /etc/systemd/system/*.wants/*;                      \
+    rm -f /lib/systemd/system/local-fs.target.wants/*;        \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*;    \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;           \
+    rm -f /lib/systemd/system/anaconda.target.wants/*      && \
+    \
+    \    
+    echo "===> Installing EPEL..."        && \
     yum -y install epel-release           && \
     \
     \
@@ -46,6 +61,19 @@ RUN echo "===> Installing EPEL..."        && \
     echo "===> Adding hosts for convenience..."    && \
     mkdir -p /etc/ansible                          && \
     echo 'localhost' > /etc/ansible/hosts
+
+
+#
+# [Quote] https://hub.docker.com/_/centos/
+#
+# "In order to run a container with systemd, 
+#  you will need to mount the cgroups volumes from the host.
+#  [...]
+#  There have been reports that if you're using an Ubuntu host,
+#  you will need to add -v /tmp/$(mktemp -d):/run
+#  in addition to the cgroups mount."
+#
+VOLUME [ "/sys/fs/cgroup", "/run" ]
 
 
 # default command: display Ansible version

--- a/centos7-onbuild/Dockerfile
+++ b/centos7-onbuild/Dockerfile
@@ -17,7 +17,22 @@ FROM centos:centos7
 MAINTAINER William Yeh <william.pjyeh@gmail.com>
 
 
-RUN echo "===> Installing EPEL..."        && \
+# enable systemd;
+# @see https://hub.docker.com/_/centos/
+ENV container docker
+
+RUN echo "===> Enabling systemd..."  && \
+    (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;      \
+    rm -f /etc/systemd/system/*.wants/*;                      \
+    rm -f /lib/systemd/system/local-fs.target.wants/*;        \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*;    \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;           \
+    rm -f /lib/systemd/system/anaconda.target.wants/*      && \
+    \
+    \    
+    echo "===> Installing EPEL..."        && \
     yum -y install epel-release           && \
     \
     \
@@ -46,6 +61,19 @@ RUN echo "===> Installing EPEL..."        && \
     echo "===> Adding hosts for convenience..."    && \
     mkdir -p /etc/ansible                          && \
     echo 'localhost' > /etc/ansible/hosts
+
+
+#
+# [Quote] https://hub.docker.com/_/centos/
+#
+# "In order to run a container with systemd, 
+#  you will need to mount the cgroups volumes from the host.
+#  [...]
+#  There have been reports that if you're using an Ubuntu host,
+#  you will need to add -v /tmp/$(mktemp -d):/run
+#  in addition to the cgroups mount."
+#
+VOLUME [ "/sys/fs/cgroup", "/run" ]
 
 
 COPY ansible-playbook-wrapper /usr/local/bin/

--- a/centos7-onbuild/ansible-playbook-wrapper
+++ b/centos7-onbuild/ansible-playbook-wrapper
@@ -13,7 +13,6 @@
 #    - INVENTORY:    inventory filename;    default = "/etc/ansible/hosts"
 #
 
-
 #
 # install Galaxy roles, if any
 #

--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -17,7 +17,22 @@ FROM centos:centos7
 MAINTAINER William Yeh <william.pjyeh@gmail.com>
 
 
-RUN echo "===> Installing EPEL..."        && \
+# enable systemd;
+# @see https://hub.docker.com/_/centos/
+ENV container docker
+
+RUN echo "===> Enabling systemd..."  && \
+    (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;      \
+    rm -f /etc/systemd/system/*.wants/*;                      \
+    rm -f /lib/systemd/system/local-fs.target.wants/*;        \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*;    \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;           \
+    rm -f /lib/systemd/system/anaconda.target.wants/*      && \
+    \
+    \
+    echo "===> Installing EPEL..."        && \
     yum -y install epel-release           && \
     \
     \
@@ -46,6 +61,18 @@ RUN echo "===> Installing EPEL..."        && \
     echo "===> Adding hosts for convenience..."    && \
     mkdir -p /etc/ansible                          && \
     echo 'localhost' > /etc/ansible/hosts
+
+#
+# [Quote] https://hub.docker.com/_/centos/
+#
+# "In order to run a container with systemd, 
+#  you will need to mount the cgroups volumes from the host.
+#  [...]
+#  There have been reports that if you're using an Ubuntu host,
+#  you will need to add -v /tmp/$(mktemp -d):/run
+#  in addition to the cgroups mount."
+#
+VOLUME [ "/sys/fs/cgroup", "/run" ]
 
 
 # default command: display Ansible version

--- a/circle.yml
+++ b/circle.yml
@@ -45,14 +45,14 @@ dependencies:
     - docker build  -t ansible_master_precise          master-ubuntu12.04
     - docker build  -t ansible_master_jessie           master-debian8
     - docker build  -t ansible_master_wheezy           master-debian7
-    #- docker build  -t ansible_master_centos7          master-centos7
+    - docker build  -t ansible_master_centos7          master-centos7
     - docker build  -t ansible_master_centos6          master-centos6
 
     - docker build  -t ansible_master_trusty_onbuild   master-ubuntu14.04-onbuild
     - docker build  -t ansible_master_precise_onbuild  master-ubuntu12.04-onbuild
     - docker build  -t ansible_master_jessie_onbuild   master-debian8-onbuild
     - docker build  -t ansible_master_wheezy_onbuild   master-debian7-onbuild
-    #- docker build  -t ansible_master_centos7_onbuild  master-centos7-onbuild
+    - docker build  -t ansible_master_centos7_onbuild  master-centos7-onbuild
     - docker build  -t ansible_master_centos6_onbuild  master-centos6-onbuild
 
 test:
@@ -93,13 +93,13 @@ test:
     - docker run -i ansible_master_precise          > result-master-ubuntu12.04
     - docker run -i ansible_master_jessie           > result-master-debian8
     - docker run -i ansible_master_wheezy           > result-master-debian7
-    #- docker run -i ansible_master_centos7          > result-master-centos7
+    - docker run -i ansible_master_centos7          > result-master-centos7
     - docker run -i ansible_master_centos6          > result-master-centos6
     - docker run -i ansible_master_trusty_onbuild   > result-master-ubuntu14.04-onbuild
     - docker run -i ansible_master_precise_onbuild  > result-master-ubuntu12.04-onbuild
     - docker run -i ansible_master_jessie_onbuild   > result-master-debian8-onbuild
     - docker run -i ansible_master_wheezy_onbuild   > result-master-debian7-onbuild
-    #- docker run -i ansible_master_centos7_onbuild  > result-master-centos7-onbuild
+    - docker run -i ansible_master_centos7_onbuild  > result-master-centos7-onbuild
     - docker run -i ansible_master_centos6_onbuild  > result-master-centos6-onbuild
 
 
@@ -139,11 +139,11 @@ test:
     - sh -c "[ -s result-master-ubuntu12.04         ]"
     - sh -c "[ -s result-master-debian8             ]"
     - sh -c "[ -s result-master-debian7             ]"
-    #- sh -c "[ -s result-master-centos7             ]"
+    - sh -c "[ -s result-master-centos7             ]"
     - sh -c "[ -s result-master-centos6             ]"
     - sh -c "[ -s result-master-ubuntu14.04-onbuild ]"
     - sh -c "[ -s result-master-ubuntu12.04-onbuild ]"
     - sh -c "[ -s result-master-debian8-onbuild     ]"
     - sh -c "[ -s result-master-debian7-onbuild     ]"
-    #- sh -c "[ -s result-master-centos7-onbuild     ]"
+    - sh -c "[ -s result-master-centos7-onbuild     ]"
     - sh -c "[ -s result-master-centos6-onbuild     ]"

--- a/master-centos7-onbuild/Dockerfile
+++ b/master-centos7-onbuild/Dockerfile
@@ -17,7 +17,22 @@ FROM centos:centos7
 MAINTAINER William Yeh <william.pjyeh@gmail.com>
 
 
-RUN echo "===> Installing EPEL..."   && \
+# enable systemd;
+# @see https://hub.docker.com/_/centos/
+ENV container docker
+
+RUN echo "===> Enabling systemd..."  && \
+    (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;      \
+    rm -f /etc/systemd/system/*.wants/*;                      \
+    rm -f /lib/systemd/system/local-fs.target.wants/*;        \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*;    \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;           \
+    rm -f /lib/systemd/system/anaconda.target.wants/*      && \
+    \
+    \    
+    echo "===> Installing EPEL..."   && \
     yum -y install epel-release      && \
     yum -y update                    && \
     \
@@ -67,6 +82,19 @@ RUN echo "===> Installing EPEL..."   && \
     echo "===> Adding hosts for convenience..."    && \
     mkdir -p /etc/ansible                          && \
     echo 'localhost' > /etc/ansible/hosts
+
+
+#
+# [Quote] https://hub.docker.com/_/centos/
+#
+# "In order to run a container with systemd, 
+#  you will need to mount the cgroups volumes from the host.
+#  [...]
+#  There have been reports that if you're using an Ubuntu host,
+#  you will need to add -v /tmp/$(mktemp -d):/run
+#  in addition to the cgroups mount."
+#
+VOLUME [ "/sys/fs/cgroup", "/run" ]
 
 
 ENV PATH        /opt/ansible/bin:$PATH

--- a/master-centos7/Dockerfile
+++ b/master-centos7/Dockerfile
@@ -17,7 +17,22 @@ FROM centos:centos7
 MAINTAINER William Yeh <william.pjyeh@gmail.com>
 
 
-RUN echo "===> Installing EPEL..."   && \
+# enable systemd;
+# @see https://hub.docker.com/_/centos/
+ENV container docker
+
+RUN echo "===> Enabling systemd..."  && \
+    (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;      \
+    rm -f /etc/systemd/system/*.wants/*;                      \
+    rm -f /lib/systemd/system/local-fs.target.wants/*;        \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*;    \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;           \
+    rm -f /lib/systemd/system/anaconda.target.wants/*      && \
+    \
+    \    
+    echo "===> Installing EPEL..."   && \
     yum -y install epel-release      && \
     yum -y update                    && \
     \
@@ -67,6 +82,19 @@ RUN echo "===> Installing EPEL..."   && \
     echo "===> Adding hosts for convenience..."    && \
     mkdir -p /etc/ansible                          && \
     echo 'localhost' > /etc/ansible/hosts
+
+
+#
+# [Quote] https://hub.docker.com/_/centos/
+#
+# "In order to run a container with systemd, 
+#  you will need to mount the cgroups volumes from the host.
+#  [...]
+#  There have been reports that if you're using an Ubuntu host,
+#  you will need to add -v /tmp/$(mktemp -d):/run
+#  in addition to the cgroups mount."
+#
+VOLUME [ "/sys/fs/cgroup", "/run" ]
 
 
 ENV PATH        /opt/ansible/bin:$PATH


### PR DESCRIPTION
Now (mid March, 2016?) the official CentOS 7 image has full support for systemd, rather than "fakesystemd".  Therefore, this commit utilizes this improvement.

@see https://hub.docker.com/_/centos/
@see https://github.com/vlisivka/docker-centos7-systemd-unpriv
