### PR TITLE
Add ansible-2.2-ubuntu16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_install:
     - docker build  -t ansible_centos6_onbuild  centos6-onbuild
     - docker build  -t ansible_alpine3_onbuild  alpine3-onbuild
 
-
     - docker build  -t ansible_1.9_trusty           1.9-ubuntu14.04
     - docker build  -t ansible_1.9_precise          1.9-ubuntu12.04
     - docker build  -t ansible_1.9_jessie           1.9-debian8
@@ -41,6 +40,7 @@ before_install:
     - docker build  -t ansible_1.9_centos6_onbuild  1.9-centos6-onbuild
     - docker build  -t ansible_1.9_alpine3_onbuild  1.9-alpine3-onbuild
 
+    - docker build  -t ansible_2.2_xenial           2.2-ubuntu16.04
 
     - docker build  -t ansible_master_xenial           master-ubuntu16.04
     - docker build  -t ansible_master_trusty           master-ubuntu14.04
@@ -99,6 +99,7 @@ script:
     - docker run -i ansible_1.9_centos6_onbuild  > result-1.9-centos6-onbuild
     - docker run -i ansible_1.9_alpine3_onbuild  > result-1.9-alpine3-onbuild
 
+    - docker run -i ansible_2.2_xenial           > result-2.2-ubuntu16.04
 
     - docker run -i ansible_master_xenial           > result-master-ubuntu16.04
     - docker run -i ansible_master_trusty           > result-master-ubuntu14.04
@@ -152,6 +153,9 @@ script:
     - sh -c "[ -s result-1.9-centos7-onbuild     ]"
     - sh -c "[ -s result-1.9-centos6-onbuild     ]"
     - sh -c "[ -s result-1.9-alpine3-onbuild     ]"
+
+    - sh -c "[ -s result-1.9-alpine3-onbuild     ]"
+    - sh -c "[ -s result-2.2-ubuntu16.04         ]"
 
     - sh -c "[ -s result-master-ubuntu16.04         ]"
     - sh -c "[ -s result-master-ubuntu14.04         ]"

--- a/2.2-ubuntu16.04/Dockerfile
+++ b/2.2-ubuntu16.04/Dockerfile
@@ -1,0 +1,67 @@
+# Dockerfile for building Ansible 2.2 image from source for Ubuntu 16.04 (Xenial), with as few additional software as possible.
+#
+# @see http://docs.ansible.com/ansible/intro_installation.html#running-from-source
+#
+# Version  1.0
+#
+
+
+# pull base image
+FROM ubuntu:16.04
+
+MAINTAINER William Yeh <william.pjyeh@gmail.com>
+
+
+RUN echo "===> Adding Ansible's prerequisites..."   && \
+    apt-get update -y            && \
+    DEBIAN_FRONTEND=noninteractive  \
+        apt-get install --no-install-recommends -y -q  \
+                build-essential                        \
+                python-pip python-dev python-yaml      \
+                libffi-dev libssl-dev                  \
+                libxml2-dev libxslt1-dev zlib1g-dev    \
+                git                                 && \
+    pip install --upgrade wheel setuptools          && \
+    pip install --upgrade pyyaml jinja2 pycrypto    && \
+    \
+    \
+    echo "===> Downloading Ansible's source tree..."            && \
+    git clone git://github.com/ansible/ansible.git --recursive  && \
+    \
+    \
+    echo "===> Compiling Ansible..."      && \
+    cd ansible                            && \
+    git checkout stable-2.2               && \
+    bash -c 'source ./hacking/env-setup'  && \
+    \
+    \
+    echo "===> Moving useful Ansible stuff to /opt/ansible ..."  && \
+    mkdir -p /opt/ansible                && \
+    mv /ansible/bin   /opt/ansible/bin   && \
+    mv /ansible/lib   /opt/ansible/lib   && \
+    mv /ansible/docs  /opt/ansible/docs  && \
+    rm -rf /ansible                      && \
+    \
+    \
+    echo "===> Installing handy tools (not absolutely required)..."  && \
+    apt-get install -y sshpass openssh-client  && \
+    \
+    \
+    echo "===> Clean up..."                                         && \
+    apt-get remove -y --auto-remove \
+            build-essential python-pip python-dev git libffi-dev libssl-dev  && \
+    apt-get clean                                                   && \
+    rm -rf /var/lib/apt/lists/*                                     && \
+    \
+    \
+    echo "===> Adding hosts for convenience..."  && \
+    mkdir -p /etc/ansible                        && \
+    echo 'localhost' > /etc/ansible/hosts
+
+
+ENV PATH        /opt/ansible/bin:$PATH
+ENV PYTHONPATH  /opt/ansible/lib:$PYTHONPATH
+ENV MANPATH     /opt/ansible/docs/man:$MANPATH
+
+# default command: display Ansible version
+CMD [ "ansible-playbook", "--version" ]

--- a/circle.yml
+++ b/circle.yml
@@ -42,6 +42,7 @@ dependencies:
     - docker build  -t ansible_1.9_centos6_onbuild  1.9-centos6-onbuild
     - docker build  -t ansible_1.9_alpine3_onbuild  1.9-alpine3-onbuild
 
+    - docker build  -t ansible_2.2_xenial           2.2-ubuntu16.04
 
     - docker build  -t ansible_master_xenial           master-ubuntu16.04
     - docker build  -t ansible_master_trusty           master-ubuntu14.04
@@ -101,6 +102,7 @@ test:
     - docker run -i ansible_1.9_centos6_onbuild  > result-1.9-centos6-onbuild
     - docker run -i ansible_1.9_alpine3_onbuild  > result-1.9-alpine3-onbuild
 
+    - docker run -i ansible_2.2_xenial           > result-2.2-ubuntu16.04
 
     - docker run -i ansible_master_xenial           > result-master-ubuntu16.04
     - docker run -i ansible_master_trusty           > result-master-ubuntu14.04
@@ -154,6 +156,8 @@ test:
     - sh -c "[ -s result-1.9-centos7-onbuild     ]"
     - sh -c "[ -s result-1.9-centos6-onbuild     ]"
     - sh -c "[ -s result-1.9-alpine3-onbuild     ]"
+
+    - sh -c "[ -s result-2.2-ubuntu16.04         ]"
 
     - sh -c "[ -s result-master-ubuntu16.04         ]"
     - sh -c "[ -s result-master-ubuntu14.04         ]"


### PR DESCRIPTION
Ansible 2.2 is not yet available in pip, but it has a bunch of cool features.
This docker image is the only convenient way to use it.
So adding 2.2 image.
