### PR TITLE
Add debian9 (stretch) images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ before_install:
     - docker build  -t ansible_mini_debian9    mini-debian9
     - docker build  -t nginx_alpine3   -f mini-test/Dockerfile.alpine3   mini-test
     - docker build  -t nginx_debian8   -f mini-test/Dockerfile.debian8   mini-test
+    - docker build  -t nginx_debian8   -f mini-test/Dockerfile.debian8   mini-test
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
     - docker build  -t ansible_trusty           ubuntu14.04
     - docker build  -t ansible_precise          ubuntu12.04
     - docker build  -t ansible_jessie           debian8
+    - docker build  -t ansible_stretch          debian9
     - docker build  -t ansible_wheezy           debian7
     - docker build  -t ansible_centos7          centos7
     - docker build  -t ansible_centos6          centos6
@@ -19,6 +20,7 @@ before_install:
     - docker build  -t ansible_trusty_onbuild   ubuntu14.04-onbuild
     - docker build  -t ansible_precise_onbuild  ubuntu12.04-onbuild
     - docker build  -t ansible_jessie_onbuild   debian8-onbuild
+    - docker build  -t ansible_stretch_onbuild  debian9-onbuild
     - docker build  -t ansible_wheezy_onbuild   debian7-onbuild
     - docker build  -t ansible_centos7_onbuild  centos7-onbuild
     - docker build  -t ansible_centos6_onbuild  centos6-onbuild
@@ -28,6 +30,7 @@ before_install:
     - docker build  -t ansible_1.9_trusty           1.9-ubuntu14.04
     - docker build  -t ansible_1.9_precise          1.9-ubuntu12.04
     - docker build  -t ansible_1.9_jessie           1.9-debian8
+    - docker build  -t ansible_1.9_stretch          1.9-debian9
     - docker build  -t ansible_1.9_wheezy           1.9-debian7
     - docker build  -t ansible_1.9_centos7          1.9-centos7
     - docker build  -t ansible_1.9_centos6          1.9-centos6
@@ -36,6 +39,7 @@ before_install:
     - docker build  -t ansible_1.9_trusty_onbuild   1.9-ubuntu14.04-onbuild
     - docker build  -t ansible_1.9_precise_onbuild  1.9-ubuntu12.04-onbuild
     - docker build  -t ansible_1.9_jessie_onbuild   1.9-debian8-onbuild
+    - docker build  -t ansible_1.9_stretch_onbuild  1.9-debian9-onbuild
     - docker build  -t ansible_1.9_wheezy_onbuild   1.9-debian7-onbuild
     - docker build  -t ansible_1.9_centos7_onbuild  1.9-centos7-onbuild
     - docker build  -t ansible_1.9_centos6_onbuild  1.9-centos6-onbuild
@@ -46,6 +50,7 @@ before_install:
     - docker build  -t ansible_master_trusty           master-ubuntu14.04
     - docker build  -t ansible_master_precise          master-ubuntu12.04
     - docker build  -t ansible_master_jessie           master-debian8
+    - docker build  -t ansible_master_stretch          master-debian9
     - docker build  -t ansible_master_wheezy           master-debian7
     - docker build  -t ansible_master_centos7          master-centos7
     - docker build  -t ansible_master_centos6          master-centos6
@@ -54,6 +59,7 @@ before_install:
     - docker build  -t ansible_master_trusty_onbuild   master-ubuntu14.04-onbuild
     - docker build  -t ansible_master_precise_onbuild  master-ubuntu12.04-onbuild
     - docker build  -t ansible_master_jessie_onbuild   master-debian8-onbuild
+    - docker build  -t ansible_master_stretch_onbuild  master-debian9-onbuild
     - docker build  -t ansible_master_wheezy_onbuild   master-debian7-onbuild
     - docker build  -t ansible_master_centos7_onbuild  master-centos7-onbuild
     - docker build  -t ansible_master_centos6_onbuild  master-centos6-onbuild
@@ -61,6 +67,7 @@ before_install:
 
     - docker build  -t ansible_mini_alpine3    mini-alpine3
     - docker build  -t ansible_mini_debian8    mini-debian8
+    - docker build  -t ansible_mini_debian9    mini-debian9
     - docker build  -t nginx_alpine3   -f mini-test/Dockerfile.alpine3   mini-test
     - docker build  -t nginx_debian8   -f mini-test/Dockerfile.debian8   mini-test
 
@@ -70,6 +77,7 @@ script:
     - docker run -i ansible_trusty           > result-ubuntu14.04
     - docker run -i ansible_precise          > result-ubuntu12.04
     - docker run -i ansible_jessie           > result-debian8
+    - docker run -i ansible_stretch          > result-debian9
     - docker run -i ansible_wheezy           > result-debian7
     - docker run -i ansible_centos7          > result-centos7
     - docker run -i ansible_centos6          > result-centos6
@@ -78,6 +86,7 @@ script:
     - docker run -i ansible_trusty_onbuild   > result-ubuntu14.04-onbuild
     - docker run -i ansible_precise_onbuild  > result-ubuntu12.04-onbuild
     - docker run -i ansible_jessie_onbuild   > result-debian8-onbuild
+    - docker run -i ansible_stretch_onbuild  > result-debian9-onbuild
     - docker run -i ansible_wheezy_onbuild   > result-debian7-onbuild
     - docker run -i ansible_centos7_onbuild  > result-centos7-onbuild
     - docker run -i ansible_centos6_onbuild  > result-centos6-onbuild
@@ -87,6 +96,7 @@ script:
     - docker run -i ansible_1.9_trusty           > result-1.9-ubuntu14.04
     - docker run -i ansible_1.9_precise          > result-1.9-ubuntu12.04
     - docker run -i ansible_1.9_jessie           > result-1.9-debian8
+    - docker run -i ansible_1.9_stretch          > result-1.9-debian9
     - docker run -i ansible_1.9_wheezy           > result-1.9-debian7
     - docker run -i ansible_1.9_centos7          > result-1.9-centos7
     - docker run -i ansible_1.9_centos6          > result-1.9-centos6
@@ -94,6 +104,7 @@ script:
     - docker run -i ansible_1.9_trusty_onbuild   > result-1.9-ubuntu14.04-onbuild
     - docker run -i ansible_1.9_precise_onbuild  > result-1.9-ubuntu12.04-onbuild
     - docker run -i ansible_1.9_jessie_onbuild   > result-1.9-debian8-onbuild
+    - docker run -i ansible_1.9_stretch_onbuild  > result-1.9-debian9-onbuild
     - docker run -i ansible_1.9_wheezy_onbuild   > result-1.9-debian7-onbuild
     - docker run -i ansible_1.9_centos7_onbuild  > result-1.9-centos7-onbuild
     - docker run -i ansible_1.9_centos6_onbuild  > result-1.9-centos6-onbuild
@@ -104,6 +115,7 @@ script:
     - docker run -i ansible_master_trusty           > result-master-ubuntu14.04
     - docker run -i ansible_master_precise          > result-master-ubuntu12.04
     - docker run -i ansible_master_jessie           > result-master-debian8
+    - docker run -i ansible_master_stretch          > result-master-debian9
     - docker run -i ansible_master_wheezy           > result-master-debian7
     - docker run -i ansible_master_centos7          > result-master-centos7
     - docker run -i ansible_master_centos6          > result-master-centos6
@@ -111,6 +123,7 @@ script:
     - docker run -i ansible_master_trusty_onbuild   > result-master-ubuntu14.04-onbuild
     - docker run -i ansible_master_precise_onbuild  > result-master-ubuntu12.04-onbuild
     - docker run -i ansible_master_jessie_onbuild   > result-master-debian8-onbuild
+    - docker run -i ansible_master_stretch_onbuild  > result-master-debian9-onbuild
     - docker run -i ansible_master_wheezy_onbuild   > result-master-debian7-onbuild
     - docker run -i ansible_master_centos7_onbuild  > result-master-centos7-onbuild
     - docker run -i ansible_master_centos6_onbuild  > result-master-centos6-onbuild
@@ -118,6 +131,7 @@ script:
 
     - docker run -i nginx_alpine3  2> result-nginx-alpine3
     - docker run -i nginx_debian8  2> result-nginx-debian8
+    - docker run -i nginx_debian9  2> result-nginx-debian9
 
 
     - echo "==> Validating the test results..."
@@ -125,6 +139,7 @@ script:
     - sh -c "[ -s result-ubuntu14.04         ]"
     - sh -c "[ -s result-ubuntu12.04         ]"
     - sh -c "[ -s result-debian8             ]"
+    - sh -c "[ -s result-debian9             ]"
     - sh -c "[ -s result-debian7             ]"
     - sh -c "[ -s result-centos7             ]"
     - sh -c "[ -s result-centos6             ]"
@@ -133,6 +148,7 @@ script:
     - sh -c "[ -s result-ubuntu14.04-onbuild ]"
     - sh -c "[ -s result-ubuntu12.04-onbuild ]"
     - sh -c "[ -s result-debian8-onbuild     ]"
+    - sh -c "[ -s result-debian9-onbuild     ]"
     - sh -c "[ -s result-debian7-onbuild     ]"
     - sh -c "[ -s result-centos7-onbuild     ]"
     - sh -c "[ -s result-centos6-onbuild     ]"
@@ -140,6 +156,7 @@ script:
 
     - sh -c "[ -s result-1.9-ubuntu14.04         ]"
     - sh -c "[ -s result-1.9-ubuntu12.04         ]"
+    - sh -c "[ -s result-1.9-debian9             ]"
     - sh -c "[ -s result-1.9-debian8             ]"
     - sh -c "[ -s result-1.9-debian7             ]"
     - sh -c "[ -s result-1.9-centos7             ]"
@@ -147,6 +164,7 @@ script:
     - sh -c "[ -s result-1.9-alpine3             ]"
     - sh -c "[ -s result-1.9-ubuntu14.04-onbuild ]"
     - sh -c "[ -s result-1.9-ubuntu12.04-onbuild ]"
+    - sh -c "[ -s result-1.9-debian9-onbuild     ]"
     - sh -c "[ -s result-1.9-debian8-onbuild     ]"
     - sh -c "[ -s result-1.9-debian7-onbuild     ]"
     - sh -c "[ -s result-1.9-centos7-onbuild     ]"
@@ -156,6 +174,7 @@ script:
     - sh -c "[ -s result-master-ubuntu16.04         ]"
     - sh -c "[ -s result-master-ubuntu14.04         ]"
     - sh -c "[ -s result-master-ubuntu12.04         ]"
+    - sh -c "[ -s result-master-debian9             ]"
     - sh -c "[ -s result-master-debian8             ]"
     - sh -c "[ -s result-master-debian7             ]"
     - sh -c "[ -s result-master-centos7             ]"
@@ -163,6 +182,7 @@ script:
     - sh -c "[ -s result-master-ubuntu16.04-onbuild ]"
     - sh -c "[ -s result-master-ubuntu14.04-onbuild ]"
     - sh -c "[ -s result-master-ubuntu12.04-onbuild ]"
+    - sh -c "[ -s result-master-debian9-onbuild     ]"
     - sh -c "[ -s result-master-debian8-onbuild     ]"
     - sh -c "[ -s result-master-debian7-onbuild     ]"
     - sh -c "[ -s result-master-centos7-onbuild     ]"
@@ -170,3 +190,4 @@ script:
 
     - sh -c "[ -s result-nginx-alpine3     ]"
     - sh -c "[ -s result-nginx-debian8     ]"
+    - sh -c "[ -s result-nginx-debian9     ]"

--- a/1.9-debian9-onbuild/Dockerfile
+++ b/1.9-debian9-onbuild/Dockerfile
@@ -1,0 +1,56 @@
+# Dockerfile for building Ansible 1.9 image for Debian 9 (stretch), with as few additional software as possible.
+#
+# @see https://launchpad.net/~ansible/+archive/ubuntu/ansible
+#
+# Version  1.0
+#
+
+
+# pull base image
+FROM debian:stretch
+
+MAINTAINER William Yeh <william.pjyeh@gmail.com>
+
+
+RUN echo "===> Installing python, sudo, and supporting tools..."  && \
+    apt-get update -y  &&  apt-get install --fix-missing          && \
+    DEBIAN_FRONTEND=noninteractive         \
+    apt-get install -y                     \
+        python python-yaml sudo            \
+        curl gcc python-pip python-dev libffi-dev libssl-dev  && \
+    apt-get -y --purge remove python-cffi          && \
+    pip install --upgrade cffi                     && \
+    \
+    \
+    echo "===> Installing Ansible..."   && \
+    pip install ansible==1.9.4          && \
+    \
+    \
+    echo "===> Removing unused APT resources..."                  && \
+    apt-get -f -y --auto-remove remove \
+                 gcc python-pip python-dev libffi-dev libssl-dev  && \
+    apt-get clean                                                 && \
+    rm -rf /var/lib/apt/lists/*  /tmp/*                           && \
+    \
+    \
+    echo "===> Adding hosts for convenience..."        && \
+    mkdir -p /etc/ansible                              && \
+    echo 'localhost' > /etc/ansible/hosts
+
+
+COPY ansible-playbook-wrapper /usr/local/bin/
+
+ONBUILD  RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
+              echo "===> Updating TLS certificates..."         && \
+              apt-get install -y openssl ca-certificates
+
+ONBUILD  WORKDIR  /tmp
+ONBUILD  COPY  .  /tmp
+ONBUILD  RUN  \
+              echo "===> Diagnosis: host information..."  && \
+              ansible -c local -m setup all
+
+
+
+# default command: display Ansible version
+CMD [ "ansible-playbook", "--version" ]

--- a/1.9-debian9-onbuild/ansible-playbook-wrapper
+++ b/1.9-debian9-onbuild/ansible-playbook-wrapper
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# Simple wrapper for executing ansible-galaxy and ansible-playbook
+# with local connection.
+#
+# USAGE:
+#    ansible-playbook-wrapper  [other ansible-playbook arguments]
+#
+# ENVIRONMENT VARIABLES:
+#
+#    - REQUIREMENTS: requirements filename; default = "requirements.yml"
+#    - PLAYBOOK:     playbook filename;     default = "playbook.yml"
+#    - INVENTORY:    inventory filename;    default = "/etc/ansible/hosts"
+#
+
+
+#
+# install Galaxy roles, if any
+#
+
+if [ -z "$REQUIREMENTS" ]; then
+    REQUIREMENTS=requirements.yml
+fi
+
+if [ -f "$REQUIREMENTS" ]; then
+    apt-get install -y git
+    ansible-galaxy install -r $REQUIREMENTS
+fi
+
+
+#
+# execute playbook
+#
+
+if [ -z "$PLAYBOOK" ]; then
+    PLAYBOOK=playbook.yml
+fi
+
+
+if [ -z "$INVENTORY" ]; then
+    exec ansible-playbook        \
+       $PLAYBOOK                 \
+       --connection=local        \
+       "$@"
+else
+    exec ansible-playbook        \
+       -i $INVENTORY  $PLAYBOOK  \
+       --connection=local        \
+       "$@"
+fi

--- a/1.9-debian9/Dockerfile
+++ b/1.9-debian9/Dockerfile
@@ -1,0 +1,46 @@
+# Dockerfile for building Ansible 1.9 image for Debian 9 (stretch), with as few additional software as possible.
+#
+# @see https://launchpad.net/~ansible/+archive/ubuntu/ansible
+#
+# Version  1.0
+#
+
+
+# pull base image
+FROM debian:stretch
+
+MAINTAINER William Yeh <william.pjyeh@gmail.com>
+
+
+RUN echo "===> Installing python, sudo, and supporting tools..."  && \
+    apt-get update -y  &&  apt-get install --fix-missing          && \
+    DEBIAN_FRONTEND=noninteractive         \
+    apt-get install -y                     \
+        python python-yaml sudo            \
+        curl gcc python-pip python-dev libffi-dev libssl-dev  && \
+    apt-get -y --purge remove python-cffi          && \
+    pip install --upgrade cffi                     && \
+    \
+    \
+    echo "===> Installing Ansible..."   && \
+    pip install ansible==1.9.4          && \
+    \
+    \
+    echo "===> Installing handy tools (not absolutely required)..."  && \
+    apt-get install -y sshpass openssh-client  && \
+    \
+    \
+    echo "===> Removing unused APT resources..."                  && \
+    apt-get -f -y --auto-remove remove \
+                 gcc python-pip python-dev libffi-dev libssl-dev  && \
+    apt-get clean                                                 && \
+    rm -rf /var/lib/apt/lists/*  /tmp/*                           && \
+    \
+    \
+    echo "===> Adding hosts for convenience..."        && \
+    mkdir -p /etc/ansible                              && \
+    echo 'localhost' > /etc/ansible/hosts
+
+
+# default command: display Ansible version
+CMD [ "ansible-playbook", "--version" ]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains Dockerized [Ansible](https://github.com/ansible/ansible
 
 These are Docker images for [Ansible](https://github.com/ansible/ansible) software, installed in a selected Linux distributions.
 
-Base OS: Debian (jessie, wheezy), Ubuntu (xenial, trusty, precise), CentOS (7, 6), Alpine (3).
+Base OS: Debian (stretch, jessie, wheezy), Ubuntu (xenial, trusty, precise), CentOS (7, 6), Alpine (3).
 
 Ansible: four versions are provided -
 
@@ -37,6 +37,7 @@ Each version is further divided into two variants:
 
 - Normal variants:
 
+  - `williamyeh/ansible:debian9`
   - `williamyeh/ansible:debian8`
   - `williamyeh/ansible:debian7`
   - `williamyeh/ansible:ubuntu16.04`
@@ -48,6 +49,7 @@ Each version is further divided into two variants:
 
 - Onbuild variants (*recommended for common cases*):
 
+  - `williamyeh/ansible:debian9-onbuild`
   - `williamyeh/ansible:debian8-onbuild`
   - `williamyeh/ansible:debian7-onbuild`
   - `williamyeh/ansible:ubuntu16.04-onbuild`
@@ -66,12 +68,14 @@ Refer to “[Build Docker images with Ansible: A half-blood approach](https://gi
 
   - `williamyeh/ansible:mini-alpine3`
   - `williamyeh/ansible:mini-debian8`
+  - `williamyeh/ansible:mini-debian9`
 
 
 ### Old 1.9 version:
 
 - Normal variants:
 
+  - `williamyeh/ansible:1.9-debian9`
   - `williamyeh/ansible:1.9-debian8`
   - `williamyeh/ansible:1.9-debian7`
   - `williamyeh/ansible:1.9-ubuntu14.04`
@@ -82,6 +86,7 @@ Refer to “[Build Docker images with Ansible: A half-blood approach](https://gi
 
 - Onbuild variants (*recommended for common cases*):
 
+  - `williamyeh/ansible:1.9-debian9-onbuild`
   - `williamyeh/ansible:1.9-debian8-onbuild`
   - `williamyeh/ansible:1.9-debian7-onbuild`
   - `williamyeh/ansible:1.9-ubuntu14.04-onbuild`
@@ -95,6 +100,7 @@ Refer to “[Build Docker images with Ansible: A half-blood approach](https://gi
 
 - Normal variants:
 
+  - `williamyeh/ansible:master-debian9`
   - `williamyeh/ansible:master-debian8`
   - `williamyeh/ansible:master-debian7`
   - `williamyeh/ansible:master-ubuntu16.04`
@@ -105,6 +111,7 @@ Refer to “[Build Docker images with Ansible: A half-blood approach](https://gi
 
 - Onbuild variants (*recommended for common cases*):
 
+  - `williamyeh/ansible:master-debian9-onbuild`
   - `williamyeh/ansible:master-debian8-onbuild`
   - `williamyeh/ansible:master-debian7-onbuild`
   - `williamyeh/ansible:master-ubuntu16.04-onbuild`
@@ -175,6 +182,7 @@ williamyeh/ansible            centos6-onbuild       264.2 MB
 williamyeh/ansible            centos7-onbuild       275.3 MB
 williamyeh/ansible            debian7-onbuild       134.4 MB
 williamyeh/ansible            debian8-onbuild       178.3 MB
+williamyeh/ansible            debian9-onbuild       216.6 MB
 williamyeh/ansible            ubuntu12.04-onbuild   181.9 MB
 williamyeh/ansible            ubuntu14.04-onbuild   238.3 MB
 ```
@@ -195,6 +203,7 @@ Vagrant.configure(2) do |config|
     #config.vm.box = "ubuntu/xenial64"
     config.vm.box = "ubuntu/trusty64"
     #config.vm.box = "ubuntu/precise64"
+    #config.vm.box = "debian/stretch64"
     #config.vm.box = "debian/jessie64"
     #config.vm.box = "debian/wheezy64"
     #config.vm.box = "bento/centos-7.2"
@@ -223,6 +232,7 @@ Docker to be a rescue. Now, with these **williamyeh/ansible** series, we may tes
 #FROM williamyeh/ansible:ubuntu16.04
 FROM williamyeh/ansible:ubuntu14.04
 #FROM williamyeh/ansible:ubuntu12.04
+#FROM williamyeh/ansible:debian9
 #FROM williamyeh/ansible:debian8
 #FROM williamyeh/ansible:debian7
 #FROM williamyeh/ansible:centos7
@@ -251,6 +261,7 @@ You may also work with `onbuild` variants, which take care of many routine steps
 #FROM williamyeh/ansible:ubuntu16.04-onbuild
 FROM williamyeh/ansible:ubuntu14.04-onbuild
 #FROM williamyeh/ansible:ubuntu12.04-onbuild
+#FROM williamyeh/ansible:debian9-onbuild
 #FROM williamyeh/ansible:debian8-onbuild
 #FROM williamyeh/ansible:debian7-onbuild
 #FROM williamyeh/ansible:centos7-onbuild

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@ Vagrant.configure(2) do |config|
     docker build  -t ansible:ubuntu16.04          ubuntu16.04
     docker build  -t ansible:ubuntu14.04          ubuntu14.04
     docker build  -t ansible:ubuntu12.04          ubuntu12.04
+    docker build  -t ansible:debian9              debian9
     docker build  -t ansible:debian8              debian8
     docker build  -t ansible:debian7              debian7
     docker build  -t ansible:centos7              centos7
@@ -16,6 +17,7 @@ Vagrant.configure(2) do |config|
     docker build  -t ansible:ubuntu16.04-onbuild  ubuntu16.04-onbuild
     docker build  -t ansible:ubuntu14.04-onbuild  ubuntu14.04-onbuild
     docker build  -t ansible:ubuntu12.04-onbuild  ubuntu12.04-onbuild
+    docker build  -t ansible:debian9-onbuild      debian9-onbuild
     docker build  -t ansible:debian8-onbuild      debian8-onbuild
     docker build  -t ansible:debian7-onbuild      debian7-onbuild
     docker build  -t ansible:centos7-onbuild      centos7-onbuild

--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,7 @@ dependencies:
     - docker build  -t ansible_trusty           ubuntu14.04
     - docker build  -t ansible_precise          ubuntu12.04
     - docker build  -t ansible_jessie           debian8
+    - docker build  -t ansible_stretch          debian9
     - docker build  -t ansible_wheezy           debian7
     - docker build  -t ansible_centos7          centos7
     - docker build  -t ansible_centos6          centos6
@@ -20,6 +21,7 @@ dependencies:
     - docker build  -t ansible_trusty_onbuild   ubuntu14.04-onbuild
     - docker build  -t ansible_precise_onbuild  ubuntu12.04-onbuild
     - docker build  -t ansible_jessie_onbuild   debian8-onbuild
+    - docker build  -t ansible_stretch_onbuild  debian9-onbuild
     - docker build  -t ansible_wheezy_onbuild   debian7-onbuild
     - docker build  -t ansible_centos7_onbuild  centos7-onbuild
     - docker build  -t ansible_centos6_onbuild  centos6-onbuild
@@ -29,6 +31,7 @@ dependencies:
     - docker build  -t ansible_1.9_trusty           1.9-ubuntu14.04
     - docker build  -t ansible_1.9_precise          1.9-ubuntu12.04
     - docker build  -t ansible_1.9_jessie           1.9-debian8
+    - docker build  -t ansible_1.9_stretch          1.9-debian9
     - docker build  -t ansible_1.9_wheezy           1.9-debian7
     - docker build  -t ansible_1.9_centos7          1.9-centos7
     - docker build  -t ansible_1.9_centos6          1.9-centos6
@@ -37,6 +40,7 @@ dependencies:
     - docker build  -t ansible_1.9_trusty_onbuild   1.9-ubuntu14.04-onbuild
     - docker build  -t ansible_1.9_precise_onbuild  1.9-ubuntu12.04-onbuild
     - docker build  -t ansible_1.9_jessie_onbuild   1.9-debian8-onbuild
+    - docker build  -t ansible_1.9_stretch_onbuild  1.9-debian9-onbuild
     - docker build  -t ansible_1.9_wheezy_onbuild   1.9-debian7-onbuild
     - docker build  -t ansible_1.9_centos7_onbuild  1.9-centos7-onbuild
     - docker build  -t ansible_1.9_centos6_onbuild  1.9-centos6-onbuild
@@ -47,6 +51,7 @@ dependencies:
     - docker build  -t ansible_master_trusty           master-ubuntu14.04
     - docker build  -t ansible_master_precise          master-ubuntu12.04
     - docker build  -t ansible_master_jessie           master-debian8
+    - docker build  -t ansible_master_stretch          master-debian9
     - docker build  -t ansible_master_wheezy           master-debian7
     - docker build  -t ansible_master_centos7          master-centos7
     - docker build  -t ansible_master_centos6          master-centos6
@@ -55,6 +60,7 @@ dependencies:
     - docker build  -t ansible_master_trusty_onbuild   master-ubuntu14.04-onbuild
     - docker build  -t ansible_master_precise_onbuild  master-ubuntu12.04-onbuild
     - docker build  -t ansible_master_jessie_onbuild   master-debian8-onbuild
+    - docker build  -t ansible_master_stretch_onbuild  master-debian9-onbuild
     - docker build  -t ansible_master_wheezy_onbuild   master-debian7-onbuild
     - docker build  -t ansible_master_centos7_onbuild  master-centos7-onbuild
     - docker build  -t ansible_master_centos6_onbuild  master-centos6-onbuild
@@ -62,6 +68,7 @@ dependencies:
 
     - docker build  -t ansible_mini_alpine3    mini-alpine3
     - docker build  -t ansible_mini_debian8    mini-debian8
+    - docker build  -t ansible_mini_debian9    mini-debian9
     - docker build  -t nginx_alpine3   -f mini-test/Dockerfile.alpine3   mini-test
     - docker build  -t nginx_debian8   -f mini-test/Dockerfile.debian8   mini-test
 
@@ -72,6 +79,7 @@ test:
     - docker run -i ansible_trusty           > result-ubuntu14.04
     - docker run -i ansible_precise          > result-ubuntu12.04
     - docker run -i ansible_jessie           > result-debian8
+    - docker run -i ansible_stretch          > result-debian9
     - docker run -i ansible_wheezy           > result-debian7
     - docker run -i ansible_centos7          > result-centos7
     - docker run -i ansible_centos6          > result-centos6
@@ -80,6 +88,7 @@ test:
     - docker run -i ansible_trusty_onbuild   > result-ubuntu14.04-onbuild
     - docker run -i ansible_precise_onbuild  > result-ubuntu12.04-onbuild
     - docker run -i ansible_jessie_onbuild   > result-debian8-onbuild
+    - docker run -i ansible_stretch_onbuild  > result-debian9-onbuild
     - docker run -i ansible_wheezy_onbuild   > result-debian7-onbuild
     - docker run -i ansible_centos7_onbuild  > result-centos7-onbuild
     - docker run -i ansible_centos6_onbuild  > result-centos6-onbuild
@@ -89,6 +98,7 @@ test:
     - docker run -i ansible_1.9_trusty           > result-1.9-ubuntu14.04
     - docker run -i ansible_1.9_precise          > result-1.9-ubuntu12.04
     - docker run -i ansible_1.9_jessie           > result-1.9-debian8
+    - docker run -i ansible_1.9_stretch          > result-1.9-debian9
     - docker run -i ansible_1.9_wheezy           > result-1.9-debian7
     - docker run -i ansible_1.9_centos7          > result-1.9-centos7
     - docker run -i ansible_1.9_centos6          > result-1.9-centos6
@@ -96,6 +106,7 @@ test:
     - docker run -i ansible_1.9_trusty_onbuild   > result-1.9-ubuntu14.04-onbuild
     - docker run -i ansible_1.9_precise_onbuild  > result-1.9-ubuntu12.04-onbuild
     - docker run -i ansible_1.9_jessie_onbuild   > result-1.9-debian8-onbuild
+    - docker run -i ansible_1.9_stretch_onbuild  > result-1.9-debian9-onbuild
     - docker run -i ansible_1.9_wheezy_onbuild   > result-1.9-debian7-onbuild
     - docker run -i ansible_1.9_centos7_onbuild  > result-1.9-centos7-onbuild
     - docker run -i ansible_1.9_centos6_onbuild  > result-1.9-centos6-onbuild
@@ -106,6 +117,7 @@ test:
     - docker run -i ansible_master_trusty           > result-master-ubuntu14.04
     - docker run -i ansible_master_precise          > result-master-ubuntu12.04
     - docker run -i ansible_master_jessie           > result-master-debian8
+    - docker run -i ansible_master_stretch          > result-master-debian9
     - docker run -i ansible_master_wheezy           > result-master-debian7
     - docker run -i ansible_master_centos7          > result-master-centos7
     - docker run -i ansible_master_centos6          > result-master-centos6
@@ -113,6 +125,7 @@ test:
     - docker run -i ansible_master_trusty_onbuild   > result-master-ubuntu14.04-onbuild
     - docker run -i ansible_master_precise_onbuild  > result-master-ubuntu12.04-onbuild
     - docker run -i ansible_master_jessie_onbuild   > result-master-debian8-onbuild
+    - docker run -i ansible_master_stretch_onbuild  > result-master-debian9-onbuild
     - docker run -i ansible_master_wheezy_onbuild   > result-master-debian7-onbuild
     - docker run -i ansible_master_centos7_onbuild  > result-master-centos7-onbuild
     - docker run -i ansible_master_centos6_onbuild  > result-master-centos6-onbuild
@@ -120,6 +133,7 @@ test:
 
     - docker run -i nginx_alpine3  2> result-nginx-alpine3
     - docker run -i nginx_debian8  2> result-nginx-debian8
+    - docker run -i nginx_debian9  2> result-nginx-debian9
 
 
     - echo "==> Validating the test results..."
@@ -127,6 +141,7 @@ test:
     - sh -c "[ -s result-ubuntu14.04         ]"
     - sh -c "[ -s result-ubuntu12.04         ]"
     - sh -c "[ -s result-debian8             ]"
+    - sh -c "[ -s result-debian9             ]"
     - sh -c "[ -s result-debian7             ]"
     - sh -c "[ -s result-centos7             ]"
     - sh -c "[ -s result-centos6             ]"
@@ -135,6 +150,7 @@ test:
     - sh -c "[ -s result-ubuntu14.04-onbuild ]"
     - sh -c "[ -s result-ubuntu12.04-onbuild ]"
     - sh -c "[ -s result-debian8-onbuild     ]"
+    - sh -c "[ -s result-debian9-onbuild     ]"
     - sh -c "[ -s result-debian7-onbuild     ]"
     - sh -c "[ -s result-centos7-onbuild     ]"
     - sh -c "[ -s result-centos6-onbuild     ]"
@@ -142,6 +158,7 @@ test:
 
     - sh -c "[ -s result-1.9-ubuntu14.04         ]"
     - sh -c "[ -s result-1.9-ubuntu12.04         ]"
+    - sh -c "[ -s result-1.9-debian9             ]"
     - sh -c "[ -s result-1.9-debian8             ]"
     - sh -c "[ -s result-1.9-debian7             ]"
     - sh -c "[ -s result-1.9-centos7             ]"
@@ -149,6 +166,7 @@ test:
     - sh -c "[ -s result-1.9-alpine3             ]"
     - sh -c "[ -s result-1.9-ubuntu14.04-onbuild ]"
     - sh -c "[ -s result-1.9-ubuntu12.04-onbuild ]"
+    - sh -c "[ -s result-1.9-debian9-onbuild     ]"
     - sh -c "[ -s result-1.9-debian8-onbuild     ]"
     - sh -c "[ -s result-1.9-debian7-onbuild     ]"
     - sh -c "[ -s result-1.9-centos7-onbuild     ]"
@@ -158,6 +176,7 @@ test:
     - sh -c "[ -s result-master-ubuntu16.04         ]"
     - sh -c "[ -s result-master-ubuntu14.04         ]"
     - sh -c "[ -s result-master-ubuntu12.04         ]"
+    - sh -c "[ -s result-master-debian9             ]"
     - sh -c "[ -s result-master-debian8             ]"
     - sh -c "[ -s result-master-debian7             ]"
     - sh -c "[ -s result-master-centos7             ]"
@@ -165,6 +184,7 @@ test:
     - sh -c "[ -s result-master-ubuntu16.04-onbuild ]"
     - sh -c "[ -s result-master-ubuntu14.04-onbuild ]"
     - sh -c "[ -s result-master-ubuntu12.04-onbuild ]"
+    - sh -c "[ -s result-master-debian9-onbuild     ]"
     - sh -c "[ -s result-master-debian8-onbuild     ]"
     - sh -c "[ -s result-master-debian7-onbuild     ]"
     - sh -c "[ -s result-master-centos7-onbuild     ]"
@@ -172,3 +192,4 @@ test:
 
     - sh -c "[ -s result-nginx-alpine3     ]"
     - sh -c "[ -s result-nginx-debian8     ]"
+    - sh -c "[ -s result-nginx-debian9     ]"

--- a/compare-image-size.sh
+++ b/compare-image-size.sh
@@ -2,6 +2,7 @@
 
 
 declare -a IMAGES=( 'ansible/ubuntu14.04-ansible:stable' 'ansible/centos7-ansible:stable'  \
+         "williamyeh/ansible:debian9-onbuild"        \
          "williamyeh/ansible:debian8-onbuild"        \
          "williamyeh/ansible:debian7-onbuild"        \
          "williamyeh/ansible:ubuntu16.04-onbuild"    \

--- a/debian9-onbuild/Dockerfile
+++ b/debian9-onbuild/Dockerfile
@@ -1,0 +1,56 @@
+# Dockerfile for building Ansible image for Debian 9 (stretch), with as few additional software as possible.
+#
+# @see https://launchpad.net/~ansible/+archive/ubuntu/ansible
+#
+# Version  1.0
+#
+
+
+# pull base image
+FROM debian:stretch
+
+MAINTAINER William Yeh <william.pjyeh@gmail.com>
+
+
+RUN echo "===> Installing python, sudo, and supporting tools..."  && \
+    apt-get update -y  &&  apt-get install --fix-missing          && \
+    DEBIAN_FRONTEND=noninteractive         \
+    apt-get install -y                     \
+        python python-yaml sudo            \
+        curl gcc python-pip python-dev libffi-dev libssl-dev  && \
+    apt-get -y --purge remove python-cffi          && \
+    pip install --upgrade cffi                     && \
+    \
+    \
+    echo "===> Installing Ansible..."   && \
+    pip install ansible                 && \
+    \
+    \
+    echo "===> Removing unused APT resources..."                  && \
+    apt-get -f -y --auto-remove remove \
+                 gcc python-pip python-dev libffi-dev libssl-dev  && \
+    apt-get clean                                                 && \
+    rm -rf /var/lib/apt/lists/*  /tmp/*                           && \
+    \
+    \
+    echo "===> Adding hosts for convenience..."        && \
+    mkdir -p /etc/ansible                              && \
+    echo 'localhost' > /etc/ansible/hosts
+
+
+COPY ansible-playbook-wrapper /usr/local/bin/
+
+ONBUILD  RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
+              echo "===> Updating TLS certificates..."         && \
+              apt-get install -y openssl ca-certificates
+
+ONBUILD  WORKDIR  /tmp
+ONBUILD  COPY  .  /tmp
+ONBUILD  RUN  \
+              echo "===> Diagnosis: host information..."  && \
+              ansible -c local -m setup all
+
+
+
+# default command: display Ansible version
+CMD [ "ansible-playbook", "--version" ]

--- a/debian9-onbuild/ansible-playbook-wrapper
+++ b/debian9-onbuild/ansible-playbook-wrapper
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# Simple wrapper for executing ansible-galaxy and ansible-playbook
+# with local connection.
+#
+# USAGE:
+#    ansible-playbook-wrapper  [other ansible-playbook arguments]
+#
+# ENVIRONMENT VARIABLES:
+#
+#    - REQUIREMENTS: requirements filename; default = "requirements.yml"
+#    - PLAYBOOK:     playbook filename;     default = "playbook.yml"
+#    - INVENTORY:    inventory filename;    default = "/etc/ansible/hosts"
+#
+
+
+#
+# install Galaxy roles, if any
+#
+
+if [ -z "$REQUIREMENTS" ]; then
+    REQUIREMENTS=requirements.yml
+fi
+
+if [ -f "$REQUIREMENTS" ]; then
+    apt-get install -y git
+    ansible-galaxy install -r $REQUIREMENTS
+fi
+
+
+#
+# execute playbook
+#
+
+if [ -z "$PLAYBOOK" ]; then
+    PLAYBOOK=playbook.yml
+fi
+
+
+if [ -z "$INVENTORY" ]; then
+    exec ansible-playbook        \
+       $PLAYBOOK                 \
+       --connection=local        \
+       "$@"
+else
+    exec ansible-playbook        \
+       -i $INVENTORY  $PLAYBOOK  \
+       --connection=local        \
+       "$@"
+fi

--- a/debian9/Dockerfile
+++ b/debian9/Dockerfile
@@ -1,0 +1,46 @@
+# Dockerfile for building Ansible image for Debian 9 (stretch), with as few additional software as possible.
+#
+# @see https://launchpad.net/~ansible/+archive/ubuntu/ansible
+#
+# Version  1.0
+#
+
+
+# pull base image
+FROM debian:stretch
+
+MAINTAINER William Yeh <william.pjyeh@gmail.com>
+
+
+RUN echo "===> Installing python, sudo, and supporting tools..."  && \
+    apt-get update -y  &&  apt-get install --fix-missing          && \
+    DEBIAN_FRONTEND=noninteractive         \
+    apt-get install -y                     \
+        python python-yaml sudo            \
+        curl gcc python-pip python-dev libffi-dev libssl-dev  && \
+    apt-get -y --purge remove python-cffi          && \
+    pip install --upgrade cffi                     && \
+    \
+    \
+    echo "===> Installing Ansible..."   && \
+    pip install ansible                 && \
+    \
+    \
+    echo "===> Installing handy tools (not absolutely required)..."  && \
+    apt-get install -y sshpass openssh-client  && \
+    \
+    \
+    echo "===> Removing unused APT resources..."                  && \
+    apt-get -f -y --auto-remove remove \
+                 gcc python-pip python-dev libffi-dev libssl-dev  && \
+    apt-get clean                                                 && \
+    rm -rf /var/lib/apt/lists/*  /tmp/*                           && \
+    \
+    \
+    echo "===> Adding hosts for convenience..."        && \
+    mkdir -p /etc/ansible                              && \
+    echo 'localhost' > /etc/ansible/hosts
+
+
+# default command: display Ansible version
+CMD [ "ansible-playbook", "--version" ]

--- a/master-debian9-onbuild/Dockerfile
+++ b/master-debian9-onbuild/Dockerfile
@@ -1,0 +1,78 @@
+# Dockerfile for building Ansible image from source for Debian 9 (stretch), with as few additional software as possible.
+#
+# @see http://docs.ansible.com/ansible/intro_installation.html#running-from-source
+#
+# Version  1.0
+#
+
+
+# pull base image
+FROM debian:stretch
+
+MAINTAINER William Yeh <william.pjyeh@gmail.com>
+
+
+RUN echo "===> Adding Ansible's prerequisites..."         && \
+    apt-get update -y  &&  apt-get install --fix-missing  && \
+    DEBIAN_FRONTEND=noninteractive  \
+        apt-get install --no-install-recommends -y -q  \
+                build-essential ca-certificates        \
+                python-pip python-dev python-yaml      \
+                libffi-dev libssl-dev                  \
+                libxml2-dev libxslt1-dev zlib1g-dev    \
+                git sudo curl                       && \
+    apt-get -y --purge remove python-cffi           && \
+    pip install --upgrade cffi                      && \
+    pip install --upgrade pyyaml jinja2 pycrypto    && \
+    \
+    \
+    echo "===> Downloading Ansible's source tree..."            && \
+    git clone git://github.com/ansible/ansible.git --recursive  && \
+    \
+    \
+    echo "===> Compiling Ansible..."      && \
+    cd ansible                            && \
+    bash -c 'source ./hacking/env-setup'  && \
+    \
+    \
+    echo "===> Moving useful Ansible stuff to /opt/ansible ..."  && \
+    mkdir -p /opt/ansible                && \
+    mv /ansible/bin   /opt/ansible/bin   && \
+    mv /ansible/lib   /opt/ansible/lib   && \
+    mv /ansible/docs  /opt/ansible/docs  && \
+    rm -rf /ansible                      && \
+    \
+    \
+    echo "===> Clean up..."                                                  && \
+    apt-get remove -y --auto-remove \
+            build-essential python-pip python-dev git libffi-dev libssl-dev  && \
+    apt-get clean                                                            && \
+    rm -rf /var/lib/apt/lists/*                                              && \
+    \
+    \
+    echo "===> Adding hosts for convenience..."  && \
+    mkdir -p /etc/ansible                        && \
+    echo 'localhost' > /etc/ansible/hosts
+
+
+ENV PATH        /opt/ansible/bin:$PATH
+ENV PYTHONPATH  /opt/ansible/lib:$PYTHONPATH
+ENV MANPATH     /opt/ansible/docs/man:$MANPATH
+
+
+COPY ansible-playbook-wrapper /usr/local/bin/
+
+ONBUILD  RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
+              echo "===> Updating TLS certificates..."         && \
+              apt-get install -y openssl ca-certificates
+
+ONBUILD  WORKDIR  /tmp
+ONBUILD  COPY  .  /tmp
+ONBUILD  RUN  \
+              echo "===> Diagnosis: host information..."  && \
+              ansible -c local -m setup all
+
+
+
+# default command: display Ansible version
+CMD [ "ansible-playbook", "--version" ]

--- a/master-debian9-onbuild/ansible-playbook-wrapper
+++ b/master-debian9-onbuild/ansible-playbook-wrapper
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# Simple wrapper for executing ansible-galaxy and ansible-playbook
+# with local connection.
+#
+# USAGE:
+#    ansible-playbook-wrapper  [other ansible-playbook arguments]
+#
+# ENVIRONMENT VARIABLES:
+#
+#    - REQUIREMENTS: requirements filename; default = "requirements.yml"
+#    - PLAYBOOK:     playbook filename;     default = "playbook.yml"
+#    - INVENTORY:    inventory filename;    default = "/etc/ansible/hosts"
+#
+
+
+#
+# install Galaxy roles, if any
+#
+
+if [ -z "$REQUIREMENTS" ]; then
+    REQUIREMENTS=requirements.yml
+fi
+
+if [ -f "$REQUIREMENTS" ]; then
+    apt-get install -y git
+    ansible-galaxy install -r $REQUIREMENTS
+fi
+
+
+#
+# execute playbook
+#
+
+if [ -z "$PLAYBOOK" ]; then
+    PLAYBOOK=playbook.yml
+fi
+
+
+if [ -z "$INVENTORY" ]; then
+    exec ansible-playbook        \
+       $PLAYBOOK                 \
+       --connection=local        \
+       "$@"
+else
+    exec ansible-playbook        \
+       -i $INVENTORY  $PLAYBOOK  \
+       --connection=local        \
+       "$@"
+fi

--- a/master-debian9/Dockerfile
+++ b/master-debian9/Dockerfile
@@ -1,0 +1,68 @@
+# Dockerfile for building Ansible image from source for Debian 9 (stretch), with as few additional software as possible.
+#
+# @see http://docs.ansible.com/ansible/intro_installation.html#running-from-source
+#
+# Version  1.0
+#
+
+
+# pull base image
+FROM debian:stretch
+
+MAINTAINER William Yeh <william.pjyeh@gmail.com>
+
+
+RUN echo "===> Adding Ansible's prerequisites..."         && \
+    apt-get update -y  &&  apt-get install --fix-missing  && \
+    DEBIAN_FRONTEND=noninteractive  \
+        apt-get install --no-install-recommends -y -q  \
+                build-essential ca-certificates        \
+                python-pip python-dev python-yaml      \
+                libffi-dev libssl-dev                  \
+                libxml2-dev libxslt1-dev zlib1g-dev    \
+                git sudo curl                       && \
+    apt-get -y --purge remove python-cffi           && \
+    pip install --upgrade cffi                      && \
+    pip install --upgrade pyyaml jinja2 pycrypto    && \
+    \
+    \
+    echo "===> Downloading Ansible's source tree..."            && \
+    git clone git://github.com/ansible/ansible.git --recursive  && \
+    \
+    \
+    echo "===> Compiling Ansible..."      && \
+    cd ansible                            && \
+    bash -c 'source ./hacking/env-setup'  && \
+    \
+    \
+    echo "===> Moving useful Ansible stuff to /opt/ansible ..."  && \
+    mkdir -p /opt/ansible                && \
+    mv /ansible/bin   /opt/ansible/bin   && \
+    mv /ansible/lib   /opt/ansible/lib   && \
+    mv /ansible/docs  /opt/ansible/docs  && \
+    rm -rf /ansible                      && \
+    \
+    \
+    echo "===> Installing handy tools (not absolutely required)..."  && \
+    apt-get install -y sshpass openssh-client  && \
+    \
+    \
+    echo "===> Clean up..."                                                  && \
+    apt-get remove -y --auto-remove \
+            build-essential python-pip python-dev git libffi-dev libssl-dev  && \
+    apt-get clean                                                            && \
+    rm -rf /var/lib/apt/lists/*                                              && \
+    \
+    \
+    echo "===> Adding hosts for convenience..."  && \
+    mkdir -p /etc/ansible                        && \
+    echo 'localhost' > /etc/ansible/hosts
+
+
+ENV PATH        /opt/ansible/bin:$PATH
+ENV PYTHONPATH  /opt/ansible/lib:$PYTHONPATH
+ENV MANPATH     /opt/ansible/docs/man:$MANPATH
+
+
+# default command: display Ansible version
+CMD [ "ansible-playbook", "--version" ]

--- a/mini-debian9/Dockerfile
+++ b/mini-debian9/Dockerfile
@@ -1,0 +1,27 @@
+# Dockerfile for building Debian-based image, via Ansible playbooks.
+#
+# @see http://docs.ansible.com/ansible/intro_installation.html#running-from-source
+#
+# Version  1.0
+#
+
+
+# pull base image
+FROM debian:9
+
+MAINTAINER William Yeh <william.pjyeh@gmail.com>
+
+#ENV APT_LIST  apt-list
+
+
+COPY  .  /tmp
+
+ONBUILD COPY . /tmp
+ONBUILD RUN \
+    cd /tmp                     && \
+    ./prepare-pkg-list.sh       && \
+    ./install-ansible.sh        && \
+    ./ansible-playbook-wrapper  && \
+    ./uninstall-ansible.sh      && \
+    cd /                        && \
+    rm -rf /tmp/*

--- a/mini-debian9/ansible-playbook-wrapper
+++ b/mini-debian9/ansible-playbook-wrapper
@@ -1,0 +1,49 @@
+#!/bin/sh
+#
+# Simple wrapper for executing ansible-galaxy and ansible-playbook
+# with local connection.
+#
+# USAGE:
+#    ansible-playbook-wrapper  [other ansible-playbook arguments]
+#
+# ENVIRONMENT VARIABLES:
+#
+#    - REQUIREMENTS: requirements filename; default = "requirements.yml"
+#    - PLAYBOOK:     playbook filename;     default = "playbook.yml"
+#    - INVENTORY:    inventory filename;    default = "/etc/ansible/hosts"
+#
+
+
+#
+# install Galaxy roles, if any
+#
+
+if [ -z "$REQUIREMENTS" ]; then
+    REQUIREMENTS=requirements.yml
+fi
+
+if [ -f "$REQUIREMENTS" ]; then
+    ansible-galaxy install -r $REQUIREMENTS
+fi
+
+
+#
+# execute playbook
+#
+
+if [ -z "$PLAYBOOK" ]; then
+    PLAYBOOK=playbook.yml
+fi
+
+
+if [ -z "$INVENTORY" ]; then
+    exec ansible-playbook        \
+       $PLAYBOOK                 \
+       --connection=local        \
+       "$@"
+else
+    exec ansible-playbook        \
+       -i $INVENTORY  $PLAYBOOK  \
+       --connection=local        \
+       "$@"
+fi

--- a/mini-debian9/apt-list
+++ b/mini-debian9/apt-list
@@ -1,0 +1,21 @@
+#
+# packages to be installed via APT;
+# lines beginning with "! " (an exclamation mark, followed by a space) will *not* be *uninstalled* afterwards.
+#
+
+
+# common
+#####sudo curl gcc
+
+# ssl
+#####openssl ca-certificates
+
+# python-runtime
+python
+#####python-pip python-yaml 
+
+# build-dependencies
+#####python-dev libffi-dev libssl-dev
+
+# may be required by ansible-galaxy
+git

--- a/mini-debian9/install-ansible.sh
+++ b/mini-debian9/install-ansible.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Simple wrapper for installing ansible
+#
+
+
+
+echo "===> Adding prerequisites..."
+
+apt-get update -y
+cat ___APT_INSTALL_LIST  | \
+    while read ITEM; do
+        apt-get install -y $ITEM
+    done
+
+
+
+echo "===> Installing Ansible..."
+apt-get install -y ansible
+
+
+
+echo "===> Adding hosts for convenience..."  && \
+mkdir -p /etc/ansible                        && \
+echo 'localhost' > /etc/ansible/hosts

--- a/mini-debian9/prepare-pkg-list.sh
+++ b/mini-debian9/prepare-pkg-list.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# Prepare the list of packages to be installed/uninstalled.
+#
+# ENVIRONMENT VARIABLES:
+#
+#    - APT_LIST: APT package list;  default = "apt-list"
+#
+
+echo "===> Preparing APT package list..."
+
+if [ -z "$APT_LIST" ]; then
+    APT_LIST=apt-list
+fi
+
+if [ -f "$APT_LIST" ]; then
+
+    awk '/^#/ {next}                                 \
+         { split($0,arrayA);                         \
+           for (i in arrayA) {                       \
+              if (arrayA[i] == "!") { continue; }    \
+              print arrayA[i]                        \
+           }                                         \
+         }'                                          \
+        $APT_LIST > ___APT_INSTALL_LIST
+
+    awk '/^(#|!)/ {next}                                          \
+         { split($0,arrayA); for (i in arrayA) print arrayA[i] }' \
+        $APT_LIST  |
+        awk '{ L[n++] = $0 }          \
+                END { while(n--)      \
+                      print L[n] }'   \
+            > ___APT_UNINSTALL_LIST
+
+fi
+#cat ___APT_INSTALL_LIST
+#cat ___APT_UNINSTALL_LIST

--- a/mini-debian9/uninstall-ansible.sh
+++ b/mini-debian9/uninstall-ansible.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Simple wrapper for uninstall ansible and related stuff.
+#
+
+
+echo "===> Removing Ansible..."
+apt-get -f -y --auto-remove remove ansible
+
+echo "===> Removing APT packages..."
+cat ___APT_UNINSTALL_LIST  | \
+    while read ITEM; do
+        apt-get -f -y --auto-remove remove $ITEM
+    done
+apt-get clean
+
+
+echo "===> Cleaning up package list..."
+rm -rf /etc/python  /etc/python2.7
+rm -rf /etc/ansible  /root/.ansible  /root/.cache 
+rm -rf /var/lib/apt/lists/*  /etc/apt/sources.list.d  /var/cache/*  /var/log/*

--- a/mini-test/Dockerfile.debian9
+++ b/mini-test/Dockerfile.debian9
@@ -1,0 +1,14 @@
+# Dockerfile for building (near-)minimal nginx under Debian8
+#
+
+
+# pull base image
+FROM ansible_mini_debian9
+
+MAINTAINER William Yeh <william.pjyeh@gmail.com>
+
+#ENV APK_LIST  apk-list
+
+ENTRYPOINT ["/usr/sbin/nginx"]
+#CMD ["-g", "daemon off;"]
+CMD ["-v"]


### PR DESCRIPTION
Added the creation of debian9 alias Stretch docker images
for all different flavors.

Build scripts taken from debian8 jessie as-is, however removed
jessie-backports required repo for mini-debian9 build.