### PR TITLE
optimize size and time using "--no-cache-dir"

### DIFF
--- a/1.9-alpine3-onbuild/Dockerfile
+++ b/1.9-alpine3-onbuild/Dockerfile
@@ -20,11 +20,12 @@ RUN echo "===> Installing sudo to emulate normal OS behavior..."  && \
     apk --update add python py-pip openssl ca-certificates    && \
     apk --update add --virtual build-dependencies \
                 python-dev libffi-dev openssl-dev build-base  && \
-    pip install --upgrade pip pycrypto cffi                   && \
+    pip install --upgrade pip    &&  \
+    pip install --no-cache-dir --upgrade pycrypto cffi                   && \
     \
     \
     echo "===> Installing Ansible..."  && \
-    pip install ansible==1.9.4         && \
+    pip install --no-cache-dir ansible==1.9.4         && \
     \
     \
     echo "===> Removing package list..."  && \

--- a/1.9-alpine3/Dockerfile
+++ b/1.9-alpine3/Dockerfile
@@ -20,11 +20,12 @@ RUN echo "===> Installing sudo to emulate normal OS behavior..."  && \
     apk --update add python py-pip openssl ca-certificates    && \
     apk --update add --virtual build-dependencies \
                 python-dev libffi-dev openssl-dev build-base  && \
-    pip install --upgrade pip pycrypto cffi                   && \
+    pip install --upgrade pip && \
+    pip install --no-cache-dir --upgrade pycrypto cffi                   && \
     \
     \
     echo "===> Installing Ansible..."  && \
-    pip install ansible==1.9.4         && \
+    pip install --no-cache-dir ansible==1.9.4         && \
     \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \

--- a/1.9-debian8-onbuild/Dockerfile
+++ b/1.9-debian8-onbuild/Dockerfile
@@ -19,12 +19,12 @@ RUN echo "===> Installing python, sudo, and supporting tools..."  && \
         python python-yaml sudo            \
         curl gcc python-pip python-dev libffi-dev libssl-dev  && \
     apt-get -y --purge remove python-cffi    && \
-    pip install --upgrade setuptools         && \
-    pip install --upgrade pycrypto cffi      && \
+    pip install --no-cache-dir --upgrade setuptools         && \
+    pip install --no-cache-dir --upgrade pycrypto cffi      && \
     \
     \
     echo "===> Installing Ansible..."   && \
-    pip install ansible==1.9.4          && \
+    pip install --no-cache-dir ansible==1.9.4          && \
     \
     \
     echo "===> Removing unused APT resources..."                  && \

--- a/1.9-debian8/Dockerfile
+++ b/1.9-debian8/Dockerfile
@@ -19,12 +19,12 @@ RUN echo "===> Installing python, sudo, and supporting tools..."  && \
         python python-yaml sudo            \
         curl gcc python-pip python-dev libffi-dev libssl-dev  && \
     apt-get -y --purge remove python-cffi    && \
-    pip install --upgrade setuptools         && \
-    pip install --upgrade pycrypto cffi      && \
+    pip install --no-cache-dir --upgrade setuptools         && \
+    pip install --no-cache-dir --upgrade pycrypto cffi      && \
     \
     \
     echo "===> Installing Ansible..."   && \
-    pip install ansible==1.9.4          && \
+    pip install --no-cache-dir ansible==1.9.4          && \
     \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \

--- a/alpine3-onbuild/Dockerfile
+++ b/alpine3-onbuild/Dockerfile
@@ -20,11 +20,12 @@ RUN echo "===> Installing sudo to emulate normal OS behavior..."  && \
     apk --update add python py-pip openssl ca-certificates    && \
     apk --update add --virtual build-dependencies \
                 python-dev libffi-dev openssl-dev build-base  && \
-    pip install --upgrade pip pycrypto cffi                   && \
+    pip install --upgrade pip    &&  \
+    pip install --no-cache-dir --upgrade pycrypto cffi                   && \
     \
     \
     echo "===> Installing Ansible..."  && \
-    pip install ansible                && \
+    pip install --no-cache-dir ansible                && \
     \
     \
     echo "===> Removing package list..."  && \

--- a/alpine3/Dockerfile
+++ b/alpine3/Dockerfile
@@ -20,15 +20,16 @@ RUN echo "===> Installing sudo to emulate normal OS behavior..."  && \
     apk --update add python py-pip openssl ca-certificates    && \
     apk --update add --virtual build-dependencies \
                 python-dev libffi-dev openssl-dev build-base  && \
-    pip install --upgrade pip cffi                            && \
+    pip install --upgrade pip    &&  \
+    pip install --no-cache-dir --upgrade cffi                            && \
     \
     \
     echo "===> Installing Ansible..."  && \
-    pip install ansible                && \
+    pip install --no-cache-dir ansible                && \
     \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
-    pip install --upgrade pycrypto pywinrm         && \
+    pip install --no-cache-dir --upgrade pycrypto pywinrm         && \
     apk --update add sshpass openssh-client rsync  && \
     \
     \

--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -52,7 +52,7 @@ RUN echo "===> Enabling systemd..."  && \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
     yum -y install python-pip               && \
-    pip install --upgrade pywinrm           && \
+    pip install --no-cache-dir --upgrade pywinrm           && \
     yum -y install sshpass openssh-clients  && \
     \
     \

--- a/debian8-onbuild/Dockerfile
+++ b/debian8-onbuild/Dockerfile
@@ -19,12 +19,12 @@ RUN echo "===> Installing python, sudo, and supporting tools..."  && \
         python python-yaml sudo            \
         curl gcc python-pip python-dev libffi-dev libssl-dev  && \
     apt-get -y --purge remove python-cffi    && \
-    pip install --upgrade setuptools         && \
-    pip install --upgrade pycrypto cffi      && \
+    pip install --no-cache-dir --upgrade setuptools         && \
+    pip install --no-cache-dir --upgrade pycrypto cffi      && \
     \
     \
     echo "===> Installing Ansible..."   && \
-    pip install ansible                 && \
+    pip install --no-cache-dir ansible                 && \
     \
     \
     echo "===> Removing unused APT resources..."                  && \

--- a/debian8/Dockerfile
+++ b/debian8/Dockerfile
@@ -19,9 +19,9 @@ RUN echo "===> Installing python, sudo, and supporting tools..."  && \
         python python-yaml sudo            \
         curl gcc python-pip python-dev libffi-dev libssl-dev  && \
     apt-get -y --purge remove python-cffi    && \
-    pip install --upgrade setuptools         && \
-    pip install --upgrade pycrypto           && \
-    pip install --upgrade cffi pywinrm       && \
+    pip install --no-cache-dir --upgrade setuptools         && \
+    pip install --no-cache-dir --upgrade pycrypto           && \
+    pip install --no-cache-dir --upgrade cffi pywinrm       && \
     \
     \
     echo "===> Fix strange bug under Jessie: cannot import name IncompleteRead"  && \
@@ -29,7 +29,7 @@ RUN echo "===> Installing python, sudo, and supporting tools..."  && \
     \
     \
     echo "===> Installing Ansible..."   && \
-    pip install ansible                 && \
+    pip install --no-cache-dir ansible                 && \
     \
     \
     \

--- a/debian9-onbuild/Dockerfile
+++ b/debian9-onbuild/Dockerfile
@@ -19,11 +19,11 @@ RUN echo "===> Installing python, sudo, and supporting tools..."  && \
         python python-yaml sudo            \
         curl gcc python-pip python-dev libffi-dev libssl-dev  && \
     apt-get -y --purge remove python-cffi          && \
-    pip install --upgrade pycrypto cffi            && \
+    pip install --no-cache-dir --upgrade pycrypto cffi            && \
     \
     \
     echo "===> Installing Ansible..."   && \
-    pip install ansible                 && \
+    pip install --no-cache-dir ansible                 && \
     \
     \
     echo "===> Removing unused APT resources..."                  && \

--- a/debian9/Dockerfile
+++ b/debian9/Dockerfile
@@ -19,12 +19,12 @@ RUN echo "===> Installing python, sudo, and supporting tools..."  && \
         python python-yaml sudo            \
         curl gcc python-pip python-dev libffi-dev libssl-dev  && \
     apt-get -y --purge remove python-cffi          && \
-    pip install --upgrade pycrypto cffi pywinrm    && \
+    pip install --no-cache-dir --upgrade pycrypto cffi pywinrm    && \
     \
     \
     \
     echo "===> Installing Ansible..."   && \
-    pip install ansible                 && \
+    pip install --no-cache-dir ansible                 && \
     \
     \
     \

--- a/master-centos7-onbuild/Dockerfile
+++ b/master-centos7-onbuild/Dockerfile
@@ -51,7 +51,7 @@ RUN echo "===> Enabling systemd..."  && \
                 libxml2 libxml2-devel libxslt libxslt-devel    \
                 git sudo curl                               && \
     pip install --upgrade pip  && \
-    pip install --upgrade \
+    pip install --no-cache-dir --upgrade \
         pyyaml jinja2 pycrypto paramiko httplib2            && \
     \
     \

--- a/master-centos7/Dockerfile
+++ b/master-centos7/Dockerfile
@@ -51,9 +51,9 @@ RUN echo "===> Enabling systemd..."  && \
                 libxml2 libxml2-devel libxslt libxslt-devel    \
                 git sudo curl                               && \
     pip install --upgrade pip  && \
-    pip install --upgrade \
+    pip install --no-cache-dir --upgrade \
         pyyaml jinja2 pycrypto paramiko httplib2            && \
-    pip install --upgrade pywinrm                           && \
+    pip install --no-cache-dir --upgrade pywinrm                           && \
     \
     \
     echo "===> Downloading Ansible's source tree..."            && \

--- a/master-debian8-onbuild/Dockerfile
+++ b/master-debian8-onbuild/Dockerfile
@@ -27,8 +27,8 @@ RUN echo "===> Adding Ansible's prerequisites..."         && \
     echo "===> Fix strange bug under Jessie: cannot import name IncompleteRead"  && \
     easy_install -U pip    && \
     \
-    pip install --upgrade cffi pywinrm              && \
-    pip install --upgrade pyyaml jinja2 pycrypto    && \
+    pip install --no-cache-dir --upgrade cffi pywinrm              && \
+    pip install --no-cache-dir --upgrade pyyaml jinja2 pycrypto    && \
     \
     \
     echo "===> Downloading Ansible's source tree..."            && \

--- a/master-debian8/Dockerfile
+++ b/master-debian8/Dockerfile
@@ -27,8 +27,8 @@ RUN echo "===> Adding Ansible's prerequisites..."         && \
     echo "===> Fix strange bug under Jessie: cannot import name IncompleteRead"  && \
     easy_install -U pip    && \
     \
-    pip install --upgrade cffi pywinrm              && \
-    pip install --upgrade pyyaml jinja2 pycrypto    && \
+    pip install --no-cache-dir --upgrade cffi pywinrm              && \
+    pip install --no-cache-dir --upgrade pyyaml jinja2 pycrypto    && \
     \
     \
     echo "===> Downloading Ansible's source tree..."            && \

--- a/master-debian9-onbuild/Dockerfile
+++ b/master-debian9-onbuild/Dockerfile
@@ -24,9 +24,9 @@ RUN echo "===> Adding Ansible's prerequisites..."         && \
     echo "--> Upgrading pip..."                     && \
     # @see https://github.com/pypa/pip/issues/5240#issuecomment-383129401  && \
     python -m pip install --upgrade pip             && \
-    pip install --upgrade setuptools wheel          && \
-    pip install --upgrade cffi                      && \
-    pip install --upgrade pyyaml jinja2 pycrypto    && \
+    pip install --no-cache-dir --upgrade setuptools wheel          && \
+    pip install --no-cache-dir --upgrade cffi                      && \
+    pip install --no-cache-dir --upgrade pyyaml jinja2 pycrypto    && \
     \
     \
     echo "===> Downloading Ansible's source tree..."            && \

--- a/master-debian9/Dockerfile
+++ b/master-debian9/Dockerfile
@@ -24,9 +24,9 @@ RUN echo "===> Adding Ansible's prerequisites..."         && \
     echo "--> Upgrading pip..."                     && \
     # @see https://github.com/pypa/pip/issues/5240#issuecomment-383129401  && \
     python -m pip install --upgrade pip             && \
-    pip install --upgrade setuptools wheel          && \
-    pip install --upgrade cffi pywinrm              && \
-    pip install --upgrade pyyaml jinja2 pycrypto    && \
+    pip install --no-cache-dir --upgrade setuptools wheel          && \
+    pip install --no-cache-dir --upgrade cffi pywinrm              && \
+    pip install --no-cache-dir --upgrade pyyaml jinja2 pycrypto    && \
     \
     \
     echo "===> Downloading Ansible's source tree..."            && \

--- a/master-ubuntu16.04-onbuild/Dockerfile
+++ b/master-ubuntu16.04-onbuild/Dockerfile
@@ -24,9 +24,9 @@ RUN echo "===> Adding Ansible's prerequisites..."   && \
     echo "--> Upgrading pip..."                     && \
     # @see https://github.com/pypa/pip/issues/5240#issuecomment-383129401  && \
     python -m pip install --upgrade pip             && \
-    pip install --upgrade setuptools wheel          && \
-    pip install --upgrade pyyaml jinja2 pycrypto    && \
-    pip install --upgrade pywinrm                   && \
+    pip install --no-cache-dir --upgrade setuptools wheel          && \
+    pip install --no-cache-dir --upgrade pyyaml jinja2 pycrypto    && \
+    pip install --no-cache-dir --upgrade pywinrm                   && \
     \
     \
     echo "===> Downloading Ansible's source tree..."            && \

--- a/master-ubuntu16.04/Dockerfile
+++ b/master-ubuntu16.04/Dockerfile
@@ -24,9 +24,9 @@ RUN echo "===> Adding Ansible's prerequisites..."   && \
     echo "--> Upgrading pip..."                     && \
     # @see https://github.com/pypa/pip/issues/5240#issuecomment-383129401  && \
     python -m pip install --upgrade pip             && \
-    pip install --upgrade setuptools wheel          && \
-    pip install --upgrade pyyaml jinja2 pycrypto    && \
-    pip install --upgrade pywinrm                   && \
+    pip install --no-cache-dir --upgrade setuptools wheel          && \
+    pip install --no-cache-dir --upgrade pyyaml jinja2 pycrypto    && \
+    pip install --no-cache-dir --upgrade pywinrm                   && \
     \
     \
     echo "===> Downloading Ansible's source tree..."            && \

--- a/master-ubuntu18.04-onbuild/Dockerfile
+++ b/master-ubuntu18.04-onbuild/Dockerfile
@@ -24,9 +24,9 @@ RUN echo "===> Adding Ansible's prerequisites..."   && \
     echo "--> Upgrading pip..."                     && \
     # @see https://github.com/pypa/pip/issues/5240#issuecomment-383129401  && \
     python -m pip install --upgrade pip             && \
-    pip install --upgrade setuptools wheel          && \
-    pip install --upgrade pyyaml jinja2 pycrypto    && \
-    pip install --upgrade pywinrm                   && \
+    pip install --no-cache-dir --upgrade setuptools wheel          && \
+    pip install --no-cache-dir --upgrade pyyaml jinja2 pycrypto    && \
+    pip install --no-cache-dir --upgrade pywinrm                   && \
     \
     \
     echo "===> Downloading Ansible's source tree..."            && \

--- a/master-ubuntu18.04/Dockerfile
+++ b/master-ubuntu18.04/Dockerfile
@@ -24,9 +24,9 @@ RUN echo "===> Adding Ansible's prerequisites..."   && \
     echo "--> Upgrading pip..."                     && \
     # @see https://github.com/pypa/pip/issues/5240#issuecomment-383129401  && \
     python -m pip install --upgrade pip             && \
-    pip install --upgrade setuptools wheel          && \
-    pip install --upgrade pyyaml jinja2 pycrypto    && \
-    pip install --upgrade pywinrm                   && \
+    pip install --no-cache-dir --upgrade setuptools wheel          && \
+    pip install --no-cache-dir --upgrade pyyaml jinja2 pycrypto    && \
+    pip install --no-cache-dir --upgrade pywinrm                   && \
     \
     \
     echo "===> Downloading Ansible's source tree..."            && \

--- a/mini-alpine3/install-ansible.sh
+++ b/mini-alpine3/install-ansible.sh
@@ -13,12 +13,12 @@ cat ___APK_INSTALL_LIST  | \
 
 cat ___PIP_INSTALL_LIST  | \
     while read ITEM; do
-        pip install --upgrade $ITEM
+        pip install --no-cache-dir --upgrade $ITEM
     done
 
 
 echo "===> Installing Ansible..."
-pip install ansible
+pip install --no-cache-dir ansible
 
 
 echo "===> Adding hosts for convenience..."  && \

--- a/ubuntu14.04/Dockerfile
+++ b/ubuntu14.04/Dockerfile
@@ -25,7 +25,7 @@ RUN echo "===> Adding Ansible's PPA..."  && \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
     #apt-get install -y python-pip              && \
-    #pip install --upgrade pywinrm              && \
+    #pip install --no-cache-dir --upgrade pywinrm              && \
     apt-get install -y sshpass openssh-client  && \
     \
     \

--- a/ubuntu16.04/Dockerfile
+++ b/ubuntu16.04/Dockerfile
@@ -25,7 +25,7 @@ RUN echo "===> Adding Ansible's PPA..."  && \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
     apt-get install -y python-pip              && \
-    pip install --upgrade pycrypto pywinrm     && \
+    pip install --no-cache-dir --upgrade pycrypto pywinrm     && \
     apt-get install -y sshpass openssh-client  && \
     \
     \

--- a/ubuntu18.04/Dockerfile
+++ b/ubuntu18.04/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "===> Adding Ansible's PPA..."  && \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
     apt-get install -y python-pip              && \
-    pip install --upgrade pycrypto pywinrm     && \
+    pip install --no-cache-dir --upgrade pycrypto pywinrm     && \
     apt-get install -y sshpass openssh-client  && \
     \
     \


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6