### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/1.9-debian8-onbuild/Dockerfile
+++ b/1.9-debian8-onbuild/Dockerfile
@@ -15,7 +15,7 @@ MAINTAINER William Yeh <william.pjyeh@gmail.com>
 RUN echo "===> Installing python, sudo, and supporting tools..."  && \
     apt-get update -y  &&  apt-get install --fix-missing          && \
     DEBIAN_FRONTEND=noninteractive         \
-    apt-get install -y                     \
+    apt-get --no-install-recommends -y install                     \
         python python-yaml sudo            \
         curl gcc python-pip python-dev libffi-dev libssl-dev  && \
     apt-get -y --purge remove python-cffi    && \
@@ -43,7 +43,7 @@ COPY ansible-playbook-wrapper /usr/local/bin/
 
 ONBUILD  RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
               echo "===> Updating TLS certificates..."         && \
-              apt-get install -y openssl ca-certificates
+              apt-get --no-install-recommends -y install openssl ca-certificates
 
 ONBUILD  WORKDIR  /tmp
 ONBUILD  COPY  .  /tmp

--- a/1.9-debian8-onbuild/ansible-playbook-wrapper
+++ b/1.9-debian8-onbuild/ansible-playbook-wrapper
@@ -23,7 +23,7 @@ if [ -z "$REQUIREMENTS" ]; then
 fi
 
 if [ -f "$REQUIREMENTS" ]; then
-    apt-get install -y git
+    apt-get --no-install-recommends -y install git
     ansible-galaxy install -r $REQUIREMENTS
 fi
 

--- a/1.9-debian8/Dockerfile
+++ b/1.9-debian8/Dockerfile
@@ -15,7 +15,7 @@ MAINTAINER William Yeh <william.pjyeh@gmail.com>
 RUN echo "===> Installing python, sudo, and supporting tools..."  && \
     apt-get update -y  &&  apt-get install --fix-missing          && \
     DEBIAN_FRONTEND=noninteractive         \
-    apt-get install -y                     \
+    apt-get --no-install-recommends -y install                     \
         python python-yaml sudo            \
         curl gcc python-pip python-dev libffi-dev libssl-dev  && \
     apt-get -y --purge remove python-cffi    && \
@@ -28,7 +28,7 @@ RUN echo "===> Installing python, sudo, and supporting tools..."  && \
     \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
-    apt-get install -y sshpass openssh-client  && \
+    apt-get --no-install-recommends -y install sshpass openssh-client  && \
     \
     \
     echo "===> Removing unused APT resources..."                  && \

--- a/1.9-ubuntu14.04-onbuild/Dockerfile
+++ b/1.9-ubuntu14.04-onbuild/Dockerfile
@@ -20,7 +20,7 @@ RUN echo "===> Adding Ansible's PPA..."  && \
     \
     \
     echo "===> Installing Ansible..."  && \
-    apt-get install -y ansible  && \
+    apt-get --no-install-recommends -y install ansible  && \
     \
     \
     echo "===> Removing Ansible PPA..."  && \
@@ -35,7 +35,7 @@ COPY ansible-playbook-wrapper /usr/local/bin/
 
 ONBUILD  RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
               echo "===> Updating TLS certificates..."         && \
-              apt-get install -y openssl ca-certificates
+              apt-get --no-install-recommends -y install openssl ca-certificates
 
 ONBUILD  WORKDIR  /tmp
 ONBUILD  COPY  .  /tmp

--- a/1.9-ubuntu14.04-onbuild/ansible-playbook-wrapper
+++ b/1.9-ubuntu14.04-onbuild/ansible-playbook-wrapper
@@ -23,7 +23,7 @@ if [ -z "$REQUIREMENTS" ]; then
 fi
 
 if [ -f "$REQUIREMENTS" ]; then
-    apt-get install -y git
+    apt-get --no-install-recommends -y install git
     ansible-galaxy install -r $REQUIREMENTS
 fi
 

--- a/1.9-ubuntu14.04/Dockerfile
+++ b/1.9-ubuntu14.04/Dockerfile
@@ -20,11 +20,11 @@ RUN echo "===> Adding Ansible's PPA..."  && \
     \
     \
     echo "===> Installing Ansible..."  && \
-    apt-get install -y ansible  && \
+    apt-get --no-install-recommends -y install ansible  && \
     \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
-    apt-get install -y sshpass openssh-client  && \
+    apt-get --no-install-recommends -y install sshpass openssh-client  && \
     \
     \
     echo "===> Removing Ansible PPA..."  && \

--- a/debian8-onbuild/Dockerfile
+++ b/debian8-onbuild/Dockerfile
@@ -15,7 +15,7 @@ MAINTAINER William Yeh <william.pjyeh@gmail.com>
 RUN echo "===> Installing python, sudo, and supporting tools..."  && \
     apt-get update -y  &&  apt-get install --fix-missing          && \
     DEBIAN_FRONTEND=noninteractive         \
-    apt-get install -y                     \
+    apt-get --no-install-recommends -y install                     \
         python python-yaml sudo            \
         curl gcc python-pip python-dev libffi-dev libssl-dev  && \
     apt-get -y --purge remove python-cffi    && \
@@ -43,7 +43,7 @@ COPY ansible-playbook-wrapper /usr/local/bin/
 
 ONBUILD  RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
               echo "===> Updating TLS certificates..."         && \
-              apt-get install -y openssl ca-certificates
+              apt-get --no-install-recommends -y install openssl ca-certificates
 
 ONBUILD  WORKDIR  /tmp
 ONBUILD  COPY  .  /tmp

--- a/debian8-onbuild/ansible-playbook-wrapper
+++ b/debian8-onbuild/ansible-playbook-wrapper
@@ -23,7 +23,7 @@ if [ -z "$REQUIREMENTS" ]; then
 fi
 
 if [ -f "$REQUIREMENTS" ]; then
-    apt-get install -y git
+    apt-get --no-install-recommends -y install git
     ansible-galaxy install -r $REQUIREMENTS
 fi
 

--- a/debian8/Dockerfile
+++ b/debian8/Dockerfile
@@ -15,7 +15,7 @@ MAINTAINER William Yeh <william.pjyeh@gmail.com>
 RUN echo "===> Installing python, sudo, and supporting tools..."  && \
     apt-get update -y  &&  apt-get install --fix-missing          && \
     DEBIAN_FRONTEND=noninteractive         \
-    apt-get install -y                     \
+    apt-get --no-install-recommends -y install                     \
         python python-yaml sudo            \
         curl gcc python-pip python-dev libffi-dev libssl-dev  && \
     apt-get -y --purge remove python-cffi    && \
@@ -34,7 +34,7 @@ RUN echo "===> Installing python, sudo, and supporting tools..."  && \
     \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
-    apt-get install -y sshpass openssh-client  && \
+    apt-get --no-install-recommends -y install sshpass openssh-client  && \
     \
     \
     echo "===> Removing unused APT resources..."                  && \

--- a/debian9-onbuild/Dockerfile
+++ b/debian9-onbuild/Dockerfile
@@ -15,7 +15,7 @@ MAINTAINER William Yeh <william.pjyeh@gmail.com>
 RUN echo "===> Installing python, sudo, and supporting tools..."  && \
     apt-get update -y  &&  apt-get install --fix-missing          && \
     DEBIAN_FRONTEND=noninteractive         \
-    apt-get install -y                     \
+    apt-get --no-install-recommends -y install                     \
         python python-yaml sudo            \
         curl gcc python-pip python-dev libffi-dev libssl-dev  && \
     apt-get -y --purge remove python-cffi          && \
@@ -42,7 +42,7 @@ COPY ansible-playbook-wrapper /usr/local/bin/
 
 ONBUILD  RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
               echo "===> Updating TLS certificates..."         && \
-              apt-get install -y openssl ca-certificates
+              apt-get --no-install-recommends -y install openssl ca-certificates
 
 ONBUILD  WORKDIR  /tmp
 ONBUILD  COPY  .  /tmp

--- a/debian9-onbuild/ansible-playbook-wrapper
+++ b/debian9-onbuild/ansible-playbook-wrapper
@@ -23,7 +23,7 @@ if [ -z "$REQUIREMENTS" ]; then
 fi
 
 if [ -f "$REQUIREMENTS" ]; then
-    apt-get install -y git
+    apt-get --no-install-recommends -y install git
     ansible-galaxy install -r $REQUIREMENTS
 fi
 

--- a/debian9/Dockerfile
+++ b/debian9/Dockerfile
@@ -15,7 +15,7 @@ MAINTAINER William Yeh <william.pjyeh@gmail.com>
 RUN echo "===> Installing python, sudo, and supporting tools..."  && \
     apt-get update -y  &&  apt-get install --fix-missing          && \
     DEBIAN_FRONTEND=noninteractive         \
-    apt-get install -y                     \
+    apt-get --no-install-recommends -y install                     \
         python python-yaml sudo            \
         curl gcc python-pip python-dev libffi-dev libssl-dev  && \
     apt-get -y --purge remove python-cffi          && \
@@ -29,7 +29,7 @@ RUN echo "===> Installing python, sudo, and supporting tools..."  && \
     \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
-    apt-get install -y sshpass openssh-client  && \
+    apt-get --no-install-recommends -y install sshpass openssh-client  && \
     \
     \
     echo "===> Removing unused APT resources..."                  && \

--- a/master-debian8-onbuild/Dockerfile
+++ b/master-debian8-onbuild/Dockerfile
@@ -69,7 +69,7 @@ COPY ansible-playbook-wrapper /usr/local/bin/
 
 ONBUILD  RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
               echo "===> Updating TLS certificates..."         && \
-              apt-get install -y openssl ca-certificates
+              apt-get --no-install-recommends -y install openssl ca-certificates
 
 ONBUILD  WORKDIR  /tmp
 ONBUILD  COPY  .  /tmp

--- a/master-debian8-onbuild/ansible-playbook-wrapper
+++ b/master-debian8-onbuild/ansible-playbook-wrapper
@@ -23,7 +23,7 @@ if [ -z "$REQUIREMENTS" ]; then
 fi
 
 if [ -f "$REQUIREMENTS" ]; then
-    apt-get install -y git
+    apt-get --no-install-recommends -y install git
     ansible-galaxy install -r $REQUIREMENTS
 fi
 

--- a/master-debian8/Dockerfile
+++ b/master-debian8/Dockerfile
@@ -50,7 +50,7 @@ RUN echo "===> Adding Ansible's prerequisites..."         && \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
 
-    apt-get install -y sshpass openssh-client  && \
+    apt-get --no-install-recommends -y install sshpass openssh-client  && \
     \
     \
     echo "===> Clean up..."                                                  && \

--- a/master-debian9-onbuild/Dockerfile
+++ b/master-debian9-onbuild/Dockerfile
@@ -67,7 +67,7 @@ COPY ansible-playbook-wrapper /usr/local/bin/
 
 ONBUILD  RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
               echo "===> Updating TLS certificates..."         && \
-              apt-get install -y openssl ca-certificates
+              apt-get --no-install-recommends -y install openssl ca-certificates
 
 ONBUILD  WORKDIR  /tmp
 ONBUILD  COPY  .  /tmp

--- a/master-debian9-onbuild/ansible-playbook-wrapper
+++ b/master-debian9-onbuild/ansible-playbook-wrapper
@@ -23,7 +23,7 @@ if [ -z "$REQUIREMENTS" ]; then
 fi
 
 if [ -f "$REQUIREMENTS" ]; then
-    apt-get install -y git
+    apt-get --no-install-recommends -y install git
     ansible-galaxy install -r $REQUIREMENTS
 fi
 

--- a/master-debian9/Dockerfile
+++ b/master-debian9/Dockerfile
@@ -48,7 +48,7 @@ RUN echo "===> Adding Ansible's prerequisites..."         && \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
 
-    apt-get install -y sshpass openssh-client  && \
+    apt-get --no-install-recommends -y install sshpass openssh-client  && \
     \
     \
     echo "===> Clean up..."                                                  && \

--- a/master-ubuntu16.04-onbuild/Dockerfile
+++ b/master-ubuntu16.04-onbuild/Dockerfile
@@ -67,7 +67,7 @@ COPY ansible-playbook-wrapper /usr/local/bin/
 
 ONBUILD  RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
               echo "===> Updating TLS certificates..."         && \
-              apt-get install -y openssl ca-certificates
+              apt-get --no-install-recommends -y install openssl ca-certificates
 
 ONBUILD  WORKDIR  /tmp
 ONBUILD  COPY  .  /tmp

--- a/master-ubuntu16.04-onbuild/ansible-playbook-wrapper
+++ b/master-ubuntu16.04-onbuild/ansible-playbook-wrapper
@@ -23,7 +23,7 @@ if [ -z "$REQUIREMENTS" ]; then
 fi
 
 if [ -f "$REQUIREMENTS" ]; then
-    apt-get install -y git
+    apt-get --no-install-recommends -y install git
     ansible-galaxy install -r $REQUIREMENTS
 fi
 

--- a/master-ubuntu16.04/Dockerfile
+++ b/master-ubuntu16.04/Dockerfile
@@ -47,7 +47,7 @@ RUN echo "===> Adding Ansible's prerequisites..."   && \
     \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
-    apt-get install -y sshpass openssh-client  && \
+    apt-get --no-install-recommends -y install sshpass openssh-client  && \
     \
     \
     echo "===> Clean up..."                                         && \

--- a/master-ubuntu18.04-onbuild/Dockerfile
+++ b/master-ubuntu18.04-onbuild/Dockerfile
@@ -67,7 +67,7 @@ COPY ansible-playbook-wrapper /usr/local/bin/
 
 ONBUILD  RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
               echo "===> Updating TLS certificates..."         && \
-              apt-get install -y openssl ca-certificates
+              apt-get --no-install-recommends -y install openssl ca-certificates
 
 ONBUILD  WORKDIR  /tmp
 ONBUILD  COPY  .  /tmp

--- a/master-ubuntu18.04-onbuild/ansible-playbook-wrapper
+++ b/master-ubuntu18.04-onbuild/ansible-playbook-wrapper
@@ -23,7 +23,7 @@ if [ -z "$REQUIREMENTS" ]; then
 fi
 
 if [ -f "$REQUIREMENTS" ]; then
-    apt-get install -y git
+    apt-get --no-install-recommends -y install git
     ansible-galaxy install -r $REQUIREMENTS
 fi
 

--- a/master-ubuntu18.04/Dockerfile
+++ b/master-ubuntu18.04/Dockerfile
@@ -47,7 +47,7 @@ RUN echo "===> Adding Ansible's prerequisites..."   && \
     \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
-    apt-get install -y sshpass openssh-client  && \
+    apt-get --no-install-recommends -y install sshpass openssh-client  && \
     \
     \
     echo "===> Clean up..."                                         && \

--- a/mini-debian8/install-ansible.sh
+++ b/mini-debian8/install-ansible.sh
@@ -19,7 +19,7 @@ echo "===> Adding prerequisites..."
 apt-get update -y
 cat ___APT_INSTALL_LIST  | \
     while read ITEM; do
-        apt-get install -y $ITEM
+        apt-get --no-install-recommends -y install $ITEM
     done
 
 

--- a/mini-debian9/install-ansible.sh
+++ b/mini-debian9/install-ansible.sh
@@ -12,13 +12,13 @@ echo "===> Adding prerequisites..."
 apt-get update -y
 cat ___APT_INSTALL_LIST  | \
     while read ITEM; do
-        apt-get install -y $ITEM
+        apt-get --no-install-recommends -y install $ITEM
     done
 
 
 
 echo "===> Installing Ansible..."
-apt-get install -y ansible
+apt-get --no-install-recommends -y install ansible
 
 
 

--- a/ubuntu14.04-onbuild/Dockerfile
+++ b/ubuntu14.04-onbuild/Dockerfile
@@ -20,7 +20,7 @@ RUN echo "===> Adding Ansible's PPA..."  && \
     \
     \
     echo "===> Installing Ansible..."  && \
-    apt-get install -y ansible  && \
+    apt-get --no-install-recommends -y install ansible  && \
     \
     \
     echo "===> Removing Ansible PPA..."  && \
@@ -35,7 +35,7 @@ COPY ansible-playbook-wrapper /usr/local/bin/
 
 ONBUILD  RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
               echo "===> Updating TLS certificates..."         && \
-              apt-get install -y openssl ca-certificates
+              apt-get --no-install-recommends -y install openssl ca-certificates
 
 ONBUILD  WORKDIR  /tmp
 ONBUILD  COPY  .  /tmp

--- a/ubuntu14.04-onbuild/ansible-playbook-wrapper
+++ b/ubuntu14.04-onbuild/ansible-playbook-wrapper
@@ -23,7 +23,7 @@ if [ -z "$REQUIREMENTS" ]; then
 fi
 
 if [ -f "$REQUIREMENTS" ]; then
-    apt-get install -y git
+    apt-get --no-install-recommends -y install git
     ansible-galaxy install -r $REQUIREMENTS
 fi
 

--- a/ubuntu14.04/Dockerfile
+++ b/ubuntu14.04/Dockerfile
@@ -20,13 +20,13 @@ RUN echo "===> Adding Ansible's PPA..."  && \
     \
     \
     echo "===> Installing Ansible..."  && \
-    apt-get install -y ansible  && \
+    apt-get --no-install-recommends -y install ansible  && \
     \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
-    #apt-get install -y python-pip              && \
+    #apt-get --no-install-recommends -y install python-pip              && \
     #pip install --upgrade pywinrm              && \
-    apt-get install -y sshpass openssh-client  && \
+    apt-get --no-install-recommends -y install sshpass openssh-client  && \
     \
     \
     echo "===> Removing Ansible PPA..."  && \

--- a/ubuntu16.04-onbuild/Dockerfile
+++ b/ubuntu16.04-onbuild/Dockerfile
@@ -20,7 +20,7 @@ RUN echo "===> Adding Ansible's PPA..."  && \
     \
     \
     echo "===> Installing Ansible..."  && \
-    apt-get install -y ansible  && \
+    apt-get --no-install-recommends -y install ansible  && \
     \
     \
     echo "===> Removing Ansible PPA..."  && \
@@ -35,7 +35,7 @@ COPY ansible-playbook-wrapper /usr/local/bin/
 
 ONBUILD  RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
               echo "===> Updating TLS certificates..."         && \
-              apt-get install -y openssl ca-certificates
+              apt-get --no-install-recommends -y install openssl ca-certificates
 
 ONBUILD  WORKDIR  /tmp
 ONBUILD  COPY  .  /tmp

--- a/ubuntu16.04-onbuild/ansible-playbook-wrapper
+++ b/ubuntu16.04-onbuild/ansible-playbook-wrapper
@@ -23,7 +23,7 @@ if [ -z "$REQUIREMENTS" ]; then
 fi
 
 if [ -f "$REQUIREMENTS" ]; then
-    apt-get install -y git
+    apt-get --no-install-recommends -y install git
     ansible-galaxy install -r $REQUIREMENTS
 fi
 

--- a/ubuntu16.04/Dockerfile
+++ b/ubuntu16.04/Dockerfile
@@ -20,13 +20,13 @@ RUN echo "===> Adding Ansible's PPA..."  && \
     \
     \
     echo "===> Installing Ansible..."  && \
-    apt-get install -y ansible  && \
+    apt-get --no-install-recommends -y install ansible  && \
     \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
-    apt-get install -y python-pip              && \
+    apt-get --no-install-recommends -y install python-pip              && \
     pip install --upgrade pycrypto pywinrm     && \
-    apt-get install -y sshpass openssh-client  && \
+    apt-get --no-install-recommends -y install sshpass openssh-client  && \
     \
     \
     echo "===> Removing Ansible PPA..."  && \

--- a/ubuntu18.04-onbuild/Dockerfile
+++ b/ubuntu18.04-onbuild/Dockerfile
@@ -13,7 +13,7 @@ MAINTAINER William Yeh <william.pjyeh@gmail.com>
 
 
 RUN echo "===> Adding Ansible's PPA..."  && \
-    apt-get update  &&  apt-get install -y gnupg2    && \
+    apt-get update  &&  apt-get --no-install-recommends -y install gnupg2    && \
     echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main" | tee /etc/apt/sources.list.d/ansible.list           && \
     echo "deb-src http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main" | tee -a /etc/apt/sources.list.d/ansible.list    && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 7BB9C367    && \
@@ -21,7 +21,7 @@ RUN echo "===> Adding Ansible's PPA..."  && \
     \
     \
     echo "===> Installing Ansible..."  && \
-    apt-get install -y ansible  && \
+    apt-get --no-install-recommends -y install ansible  && \
     \
     \
     echo "===> Removing Ansible PPA..."  && \
@@ -36,7 +36,7 @@ COPY ansible-playbook-wrapper /usr/local/bin/
 
 ONBUILD  RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
               echo "===> Updating TLS certificates..."         && \
-              apt-get install -y openssl ca-certificates
+              apt-get --no-install-recommends -y install openssl ca-certificates
 
 ONBUILD  WORKDIR  /tmp
 ONBUILD  COPY  .  /tmp

--- a/ubuntu18.04-onbuild/ansible-playbook-wrapper
+++ b/ubuntu18.04-onbuild/ansible-playbook-wrapper
@@ -23,7 +23,7 @@ if [ -z "$REQUIREMENTS" ]; then
 fi
 
 if [ -f "$REQUIREMENTS" ]; then
-    apt-get install -y git
+    apt-get --no-install-recommends -y install git
     ansible-galaxy install -r $REQUIREMENTS
 fi
 

--- a/ubuntu18.04/Dockerfile
+++ b/ubuntu18.04/Dockerfile
@@ -13,7 +13,7 @@ MAINTAINER William Yeh <william.pjyeh@gmail.com>
 
 
 RUN echo "===> Adding Ansible's PPA..."  && \
-    apt-get update  &&  apt-get install -y gnupg2    && \
+    apt-get update  &&  apt-get --no-install-recommends -y install gnupg2    && \
     echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main" | tee /etc/apt/sources.list.d/ansible.list           && \
     echo "deb-src http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main" | tee -a /etc/apt/sources.list.d/ansible.list    && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 7BB9C367    && \
@@ -21,13 +21,13 @@ RUN echo "===> Adding Ansible's PPA..."  && \
     \
     \
     echo "===> Installing Ansible..."  && \
-    apt-get install -y ansible  && \
+    apt-get --no-install-recommends -y install ansible  && \
     \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \
-    apt-get install -y python-pip              && \
+    apt-get --no-install-recommends -y install python-pip              && \
     pip install --upgrade pycrypto pywinrm     && \
-    apt-get install -y sshpass openssh-client  && \
+    apt-get --no-install-recommends -y install sshpass openssh-client  && \
     \
     \
     echo "===> Removing Ansible PPA..."  && \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>